### PR TITLE
Templated edlib

### DIFF
--- a/textsearch/csrc/CMakeLists.txt
+++ b/textsearch/csrc/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(textsearch_srcs
-  edlib.cc
   suffix_array.cc
 )
 

--- a/textsearch/csrc/CMakeLists.txt
+++ b/textsearch/csrc/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(textsearch_srcs
+  edlib.cc
   suffix_array.cc
 )
 
@@ -13,11 +14,17 @@ function(textsearch_add_test source)
       gtest
       gtest_main
   )
+
+  add_test(NAME "Test.${name}"
+    COMMAND
+    $<TARGET_FILE:${name}>
+  )
 endfunction()
 
 if(FTS_ENABLE_TESTS)
   # please sort the source files alphabetically
   set(test_srcs
+    edlib_test.cc
     suffix_array_test.cc
   )
 

--- a/textsearch/csrc/edlib.cc
+++ b/textsearch/csrc/edlib.cc
@@ -1,0 +1,1482 @@
+#include "edlib.h"
+
+#include <stdint.h>
+#include <cstdlib>
+#include <algorithm>
+#include <vector>
+#include <cstring>
+#include <string>
+
+using namespace std;
+
+typedef uint64_t Word;
+static const int WORD_SIZE = sizeof(Word) * 8; // Size of Word in bits
+static const Word WORD_1 = static_cast<Word>(1);
+static const Word HIGH_BIT_MASK = WORD_1 << (WORD_SIZE - 1);  // 100..00
+static const int MAX_UCHAR = 255;
+
+// Data needed to find alignment.
+struct AlignmentData {
+    Word* Ps;
+    Word* Ms;
+    int* scores;
+    int* firstBlocks;
+    int* lastBlocks;
+
+    AlignmentData(int maxNumBlocks, int targetLength) {
+        // We build a complete table and mark first and last block for each column
+        // (because algorithm is banded so only part of each columns is used).
+        // TODO: do not build a whole table, but just enough blocks for each column.
+         Ps     = new Word[maxNumBlocks * targetLength];
+         Ms     = new Word[maxNumBlocks * targetLength];
+         scores = new  int[maxNumBlocks * targetLength];
+         firstBlocks = new int[targetLength];
+         lastBlocks  = new int[targetLength];
+    }
+
+    ~AlignmentData() {
+        delete[] Ps;
+        delete[] Ms;
+        delete[] scores;
+        delete[] firstBlocks;
+        delete[] lastBlocks;
+    }
+};
+
+struct Block {
+    Word P;  // Pvin
+    Word M;  // Mvin
+    int score; // score of last cell in block;
+
+    Block() {}
+    Block(Word p, Word m, int s) :P(p), M(m), score(s) {}
+};
+
+
+/**
+ * Defines equality relation on alphabet characters.
+ * By default each character is always equal only to itself, but you can also provide additional equalities.
+ */
+class EqualityDefinition {
+private:
+    bool matrix[MAX_UCHAR + 1][MAX_UCHAR + 1];
+public:
+    EqualityDefinition(const string& alphabet,
+                       const EdlibEqualityPair* additionalEqualities = NULL,
+                       const int additionalEqualitiesLength = 0) {
+        for (int i = 0; i < static_cast<int>(alphabet.size()); i++) {
+            for (int j = 0; j < static_cast<int>(alphabet.size()); j++) {
+                matrix[i][j] = (i == j);
+            }
+        }
+        if (additionalEqualities != NULL) {
+            for (int i = 0; i < additionalEqualitiesLength; i++) {
+                size_t firstTransformed = alphabet.find(additionalEqualities[i].first);
+                size_t secondTransformed = alphabet.find(additionalEqualities[i].second);
+                if (firstTransformed != string::npos && secondTransformed != string::npos) {
+                    matrix[firstTransformed][secondTransformed] = matrix[secondTransformed][firstTransformed] = true;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param a  Element from transformed sequence.
+     * @param b  Element from transformed sequence.
+     * @return True if a and b are defined as equal, false otherwise.
+     */
+    bool areEqual(unsigned char a, unsigned char b) const {
+        return matrix[a][b];
+    }
+};
+
+static int myersCalcEditDistanceSemiGlobal(const Word* Peq, int W, int maxNumBlocks,
+                                           int queryLength,
+                                           const unsigned char* target, int targetLength,
+                                           int k, EdlibAlignMode mode,
+                                           int* bestScore_, int** positions_, int* numPositions_);
+
+static int myersCalcEditDistanceNW(const Word* Peq, int W, int maxNumBlocks,
+                                   int queryLength,
+                                   const unsigned char* target, int targetLength,
+                                   int k, int* bestScore_,
+                                   int* position_, bool findAlignment,
+                                   AlignmentData** alignData, int targetStopPosition);
+
+
+static int obtainAlignment(
+        const unsigned char* query, const unsigned char* rQuery, int queryLength,
+        const unsigned char* target, const unsigned char* rTarget, int targetLength,
+        const EqualityDefinition& equalityDefinition, int alphabetLength, int bestScore,
+        unsigned char** alignment, int* alignmentLength);
+
+static int obtainAlignmentHirschberg(
+        const unsigned char* query, const unsigned char* rQuery, int queryLength,
+        const unsigned char* target, const unsigned char* rTarget, int targetLength,
+        const EqualityDefinition& equalityDefinition, int alphabetLength, int bestScore,
+        unsigned char** alignment, int* alignmentLength);
+
+static int obtainAlignmentTraceback(int queryLength, int targetLength,
+                                    int bestScore, const AlignmentData* alignData,
+                                    unsigned char** alignment, int* alignmentLength);
+
+static string transformSequences(const char* queryOriginal, int queryLength,
+                                 const char* targetOriginal, int targetLength,
+                                 unsigned char** queryTransformed,
+                                 unsigned char** targetTransformed);
+
+static inline int ceilDiv(int x, int y);
+
+static inline unsigned char* createReverseCopy(const unsigned char* seq, int length);
+
+static inline Word* buildPeq(const int alphabetLength,
+                             const unsigned char* query,
+                             const int queryLength,
+                             const EqualityDefinition& equalityDefinition);
+
+
+/**
+ * Main edlib method.
+ */
+extern "C" EdlibAlignResult edlibAlign(const char* const queryOriginal, const int queryLength,
+                                       const char* const targetOriginal, const int targetLength,
+                                       const EdlibAlignConfig config) {
+    EdlibAlignResult result;
+    result.status = EDLIB_STATUS_OK;
+    result.editDistance = -1;
+    result.endLocations = result.startLocations = NULL;
+    result.numLocations = 0;
+    result.alignment = NULL;
+    result.alignmentLength = 0;
+    result.alphabetLength = 0;
+
+    /*------------ TRANSFORM SEQUENCES AND RECOGNIZE ALPHABET -----------*/
+    unsigned char* query, * target;
+    string alphabet = transformSequences(queryOriginal, queryLength, targetOriginal, targetLength,
+                                         &query, &target);
+    result.alphabetLength = static_cast<int>(alphabet.size());
+    /*-------------------------------------------------------*/
+
+    // Handle special situation when at least one of the sequences has length 0.
+    if (queryLength == 0 || targetLength == 0) {
+        if (config.mode == EDLIB_MODE_NW) {
+            result.editDistance = std::max(queryLength, targetLength);
+            result.endLocations = static_cast<int *>(malloc(sizeof(int) * 1));
+            result.endLocations[0] = targetLength - 1;
+            result.numLocations = 1;
+        } else if (config.mode == EDLIB_MODE_SHW || config.mode == EDLIB_MODE_HW) {
+            result.editDistance = queryLength;
+            result.endLocations = static_cast<int *>(malloc(sizeof(int) * 1));
+            result.endLocations[0] = -1;
+            result.numLocations = 1;
+        } else {
+            result.status = EDLIB_STATUS_ERROR;
+        }
+
+        free(query);
+        free(target);
+        return result;
+    }
+
+    /*--------------------- INITIALIZATION ------------------*/
+    int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE); // bmax in Myers
+    int W = maxNumBlocks * WORD_SIZE - queryLength; // number of redundant cells in last level blocks
+    EqualityDefinition equalityDefinition(alphabet, config.additionalEqualities, config.additionalEqualitiesLength);
+    Word* Peq = buildPeq(static_cast<int>(alphabet.size()), query, queryLength, equalityDefinition);
+    /*-------------------------------------------------------*/
+
+    /*------------------ MAIN CALCULATION -------------------*/
+    // TODO: Store alignment data only after k is determined? That could make things faster.
+    int positionNW; // Used only when mode is NW.
+    AlignmentData* alignData = NULL;
+    bool dynamicK = false;
+    int k = config.k;
+    if (k < 0) { // If valid k is not given, auto-adjust k until solution is found.
+        dynamicK = true;
+        k = WORD_SIZE; // Gives better results than smaller k.
+    }
+
+    do {
+        if (config.mode == EDLIB_MODE_HW || config.mode == EDLIB_MODE_SHW) {
+            myersCalcEditDistanceSemiGlobal(Peq, W, maxNumBlocks,
+                                            queryLength, target, targetLength,
+                                            k, config.mode, &(result.editDistance),
+                                            &(result.endLocations), &(result.numLocations));
+        } else {  // mode == EDLIB_MODE_NW
+            myersCalcEditDistanceNW(Peq, W, maxNumBlocks,
+                                    queryLength, target, targetLength,
+                                    k, &(result.editDistance), &positionNW,
+                                    false, &alignData, -1);
+        }
+        k *= 2;
+    } while(dynamicK && result.editDistance == -1);
+
+    if (result.editDistance >= 0) {  // If there is solution.
+        // If NW mode, set end location explicitly.
+        if (config.mode == EDLIB_MODE_NW) {
+            result.endLocations = static_cast<int *>(malloc(sizeof(int) * 1));
+            result.endLocations[0] = targetLength - 1;
+            result.numLocations = 1;
+        }
+
+        // Find starting locations.
+        if (config.task == EDLIB_TASK_LOC || config.task == EDLIB_TASK_PATH) {
+            result.startLocations = static_cast<int *>(malloc(result.numLocations * sizeof(int)));
+            if (config.mode == EDLIB_MODE_HW) {  // If HW, I need to calculate start locations.
+                const unsigned char* rTarget = createReverseCopy(target, targetLength);
+                const unsigned char* rQuery  = createReverseCopy(query, queryLength);
+                // Peq for reversed query.
+                Word* rPeq = buildPeq(static_cast<int>(alphabet.size()), rQuery, queryLength, equalityDefinition);
+                for (int i = 0; i < result.numLocations; i++) {
+                    int endLocation = result.endLocations[i];
+                    if (endLocation == -1) {
+                        // NOTE: Sometimes one of optimal solutions is that query starts before target, like this:
+                        //                       AAGG <- target
+                        //                   CCTT     <- query
+                        //   It will never be only optimal solution and it does not happen often, however it is
+                        //   possible and in that case end location will be -1. What should we do with that?
+                        //   Should we just skip reporting such end location, although it is a solution?
+                        //   If we do report it, what is the start location? -4? -1? Nothing?
+                        // TODO: Figure this out. This has to do in general with how we think about start
+                        //   and end locations.
+                        //   Also, we have alignment later relying on this locations to limit the space of it's
+                        //   search -> how can it do it right if these locations are negative or incorrect?
+                        result.startLocations[i] = 0;  // I put 0 for now, but it does not make much sense.
+                    } else {
+                        int bestScoreSHW, numPositionsSHW;
+                        int* positionsSHW;
+                        myersCalcEditDistanceSemiGlobal(
+                                rPeq, W, maxNumBlocks,
+                                queryLength, rTarget + targetLength - endLocation - 1, endLocation + 1,
+                                result.editDistance, EDLIB_MODE_SHW,
+                                &bestScoreSHW, &positionsSHW, &numPositionsSHW);
+                        // Taking last location as start ensures that alignment will not start with insertions
+                        // if it can start with mismatches instead.
+                        result.startLocations[i] = endLocation - positionsSHW[numPositionsSHW - 1];
+                        free(positionsSHW);
+                    }
+                }
+                delete[] rTarget;
+                delete[] rQuery;
+                delete[] rPeq;
+            } else {  // If mode is SHW or NW
+                for (int i = 0; i < result.numLocations; i++) {
+                    result.startLocations[i] = 0;
+                }
+            }
+        }
+
+        // Find alignment -> all comes down to finding alignment for NW.
+        // Currently we return alignment only for first pair of locations.
+        if (config.task == EDLIB_TASK_PATH) {
+            int alnStartLocation = result.startLocations[0];
+            int alnEndLocation = result.endLocations[0];
+            const unsigned char* alnTarget = target + alnStartLocation;
+            const int alnTargetLength = alnEndLocation - alnStartLocation + 1;
+            const unsigned char* rAlnTarget = createReverseCopy(alnTarget, alnTargetLength);
+            const unsigned char* rQuery  = createReverseCopy(query, queryLength);
+            obtainAlignment(query, rQuery, queryLength,
+                            alnTarget, rAlnTarget, alnTargetLength,
+                            equalityDefinition, static_cast<int>(alphabet.size()), result.editDistance,
+                            &(result.alignment), &(result.alignmentLength));
+            delete[] rAlnTarget;
+            delete[] rQuery;
+        }
+    }
+    /*-------------------------------------------------------*/
+
+    //--- Free memory ---//
+    delete[] Peq;
+    free(query);
+    free(target);
+    if (alignData) delete alignData;
+    //-------------------//
+
+    return result;
+}
+
+extern "C" char* edlibAlignmentToCigar(const unsigned char* const alignment, const int alignmentLength,
+                                       const EdlibCigarFormat cigarFormat) {
+    if (cigarFormat != EDLIB_CIGAR_EXTENDED && cigarFormat != EDLIB_CIGAR_STANDARD) {
+        return 0;
+    }
+
+    // Maps move code from alignment to char in cigar.
+    //                        0    1    2    3
+    char moveCodeToChar[] = {'=', 'I', 'D', 'X'};
+    if (cigarFormat == EDLIB_CIGAR_STANDARD) {
+        moveCodeToChar[0] = moveCodeToChar[3] = 'M';
+    }
+
+    vector<char>* cigar = new vector<char>();
+    char lastMove = 0;  // Char of last move. 0 if there was no previous move.
+    int numOfSameMoves = 0;
+    for (int i = 0; i <= alignmentLength; i++) {
+        // if new sequence of same moves started
+        if (i == alignmentLength || (moveCodeToChar[alignment[i]] != lastMove && lastMove != 0)) {
+            // Write number of moves to cigar string.
+            int numDigits = 0;
+            for (; numOfSameMoves; numOfSameMoves /= 10) {
+                cigar->push_back('0' + numOfSameMoves % 10);
+                numDigits++;
+            }
+            reverse(cigar->end() - numDigits, cigar->end());
+            // Write code of move to cigar string.
+            cigar->push_back(lastMove);
+            // If not at the end, start new sequence of moves.
+            if (i < alignmentLength) {
+                // Check if alignment has valid values.
+                if (alignment[i] > 3) {
+                    delete cigar;
+                    return 0;
+                }
+                numOfSameMoves = 0;
+            }
+        }
+        if (i < alignmentLength) {
+            lastMove = moveCodeToChar[alignment[i]];
+            numOfSameMoves++;
+        }
+    }
+    cigar->push_back(0);  // Null character termination.
+    char* cigar_ = static_cast<char *>(malloc(cigar->size() * sizeof(char)));
+    memcpy(cigar_, &(*cigar)[0], cigar->size() * sizeof(char));
+    delete cigar;
+
+    return cigar_;
+}
+
+/**
+ * Build Peq table for given query and alphabet.
+ * Peq is table of dimensions alphabetLength+1 x maxNumBlocks.
+ * Bit i of Peq[s * maxNumBlocks + b] is 1 if i-th symbol from block b of query equals symbol s, otherwise it is 0.
+ * NOTICE: free returned array with delete[]!
+ */
+static inline Word* buildPeq(const int alphabetLength,
+                             const unsigned char* const query,
+                             const int queryLength,
+                             const EqualityDefinition& equalityDefinition) {
+    int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
+    // table of dimensions alphabetLength+1 x maxNumBlocks. Last symbol is wildcard.
+    Word* Peq = new Word[(alphabetLength + 1) * maxNumBlocks];
+
+    // Build Peq (1 is match, 0 is mismatch). NOTE: last column is wildcard(symbol that matches anything) with just 1s
+    for (int symbol = 0; symbol <= alphabetLength; symbol++) {
+        for (int b = 0; b < maxNumBlocks; b++) {
+            if (symbol < alphabetLength) {
+                Peq[symbol * maxNumBlocks + b] = 0;
+                for (int r = (b+1) * WORD_SIZE - 1; r >= b * WORD_SIZE; r--) {
+                    Peq[symbol * maxNumBlocks + b] <<= 1;
+                    // NOTE: We pretend like query is padded at the end with W wildcard symbols
+                    if (r >= queryLength || equalityDefinition.areEqual(query[r], symbol))
+                        Peq[symbol * maxNumBlocks + b] += 1;
+                }
+            } else { // Last symbol is wildcard, so it is all 1s
+                Peq[symbol * maxNumBlocks + b] = static_cast<Word>(-1);
+            }
+        }
+    }
+
+    return Peq;
+}
+
+
+/**
+ * Returns new sequence that is reverse of given sequence.
+ * Free returned array with delete[].
+ */
+static inline unsigned char* createReverseCopy(const unsigned char* const seq, const int length) {
+    unsigned char* rSeq = new unsigned char[length];
+    for (int i = 0; i < length; i++) {
+        rSeq[i] = seq[length - i - 1];
+    }
+    return rSeq;
+}
+
+/**
+ * Corresponds to Advance_Block function from Myers.
+ * Calculates one word(block), which is part of a column.
+ * Highest bit of word (one most to the left) is most bottom cell of block from column.
+ * Pv[i] and Mv[i] define vin of cell[i]: vin = cell[i] - cell[i-1].
+ * @param [in] Pv  Bitset, Pv[i] == 1 if vin is +1, otherwise Pv[i] == 0.
+ * @param [in] Mv  Bitset, Mv[i] == 1 if vin is -1, otherwise Mv[i] == 0.
+ * @param [in] Eq  Bitset, Eq[i] == 1 if match, 0 if mismatch.
+ * @param [in] hin  Will be +1, 0 or -1.
+ * @param [out] PvOut  Bitset, PvOut[i] == 1 if vout is +1, otherwise PvOut[i] == 0.
+ * @param [out] MvOut  Bitset, MvOut[i] == 1 if vout is -1, otherwise MvOut[i] == 0.
+ * @param [out] hout  Will be +1, 0 or -1.
+ */
+static inline int calculateBlock(Word Pv, Word Mv, Word Eq, const int hin,
+                                 Word &PvOut, Word &MvOut) {
+    // hin can be 1, -1 or 0.
+    // 1  -> 00...01
+    // 0  -> 00...00
+    // -1 -> 11...11 (2-complement)
+
+    Word hinIsNeg = static_cast<Word>(hin >> 2) & WORD_1; // 00...001 if hin is -1, 00...000 if 0 or 1
+
+    Word Xv = Eq | Mv;
+    // This is instruction below written using 'if': if (hin < 0) Eq |= (Word)1;
+    Eq |= hinIsNeg;
+    Word Xh = (((Eq & Pv) + Pv) ^ Pv) | Eq;
+
+    Word Ph = Mv | ~(Xh | Pv);
+    Word Mh = Pv & Xh;
+
+    int hout = 0;
+    // This is instruction below written using 'if': if (Ph & HIGH_BIT_MASK) hout = 1;
+    hout = (Ph & HIGH_BIT_MASK) >> (WORD_SIZE - 1);
+    // This is instruction below written using 'if': if (Mh & HIGH_BIT_MASK) hout = -1;
+    hout -= (Mh & HIGH_BIT_MASK) >> (WORD_SIZE - 1);
+
+    Ph <<= 1;
+    Mh <<= 1;
+
+    // This is instruction below written using 'if': if (hin < 0) Mh |= (Word)1;
+    Mh |= hinIsNeg;
+    // This is instruction below written using 'if': if (hin > 0) Ph |= (Word)1;
+    Ph |= static_cast<Word>((hin + 1) >> 1);
+
+    PvOut = Mh | ~(Xv | Ph);
+    MvOut = Ph & Xv;
+
+    return hout;
+}
+
+/**
+ * Does ceiling division x / y.
+ * Note: x and y must be non-negative and x + y must not overflow.
+ */
+static inline int ceilDiv(const int x, const int y) {
+    return x % y ? x / y + 1 : x / y;
+}
+
+static inline int min(const int x, const int y) {
+    return x < y ? x : y;
+}
+
+static inline int max(const int x, const int y) {
+    return x > y ? x : y;
+}
+
+
+/**
+ * @param [in] block
+ * @return Values of cells in block, starting with bottom cell in block.
+ */
+static inline vector<int> getBlockCellValues(const Block block) {
+    vector<int> scores(WORD_SIZE);
+    int score = block.score;
+    Word mask = HIGH_BIT_MASK;
+    for (int i = 0; i < WORD_SIZE - 1; i++) {
+        scores[i] = score;
+        if (block.P & mask) score--;
+        if (block.M & mask) score++;
+        mask >>= 1;
+    }
+    scores[WORD_SIZE - 1] = score;
+    return scores;
+}
+
+/**
+ * Writes values of cells in block into given array, starting with first/top cell.
+ * @param [in] block
+ * @param [out] dest  Array into which cell values are written. Must have size of at least WORD_SIZE.
+ */
+static inline void readBlock(const Block block, int* const dest) {
+    int score = block.score;
+    Word mask = HIGH_BIT_MASK;
+    for (int i = 0; i < WORD_SIZE - 1; i++) {
+        dest[WORD_SIZE - 1 - i] = score;
+        if (block.P & mask) score--;
+        if (block.M & mask) score++;
+        mask >>= 1;
+    }
+    dest[0] = score;
+}
+
+/**
+ * Writes values of cells in block into given array, starting with last/bottom cell.
+ * @param [in] block
+ * @param [out] dest  Array into which cell values are written. Must have size of at least WORD_SIZE.
+ */
+static inline void readBlockReverse(const Block block, int* const dest) {
+    int score = block.score;
+    Word mask = HIGH_BIT_MASK;
+    for (int i = 0; i < WORD_SIZE - 1; i++) {
+        dest[i] = score;
+        if (block.P & mask) score--;
+        if (block.M & mask) score++;
+        mask >>= 1;
+    }
+    dest[WORD_SIZE - 1] = score;
+}
+
+/**
+ * @param [in] block
+ * @param [in] k
+ * @return True if all cells in block have value larger than k, otherwise false.
+ */
+static inline bool allBlockCellsLarger(const Block block, const int k) {
+    vector<int> scores = getBlockCellValues(block);
+    for (int i = 0; i < WORD_SIZE; i++) {
+        if (scores[i] <= k) return false;
+    }
+    return true;
+}
+
+
+/**
+ * Uses Myers' bit-vector algorithm to find edit distance for one of semi-global alignment methods.
+ * @param [in] Peq  Query profile.
+ * @param [in] W  Size of padding in last block.
+ *                TODO: Calculate this directly from query, instead of passing it.
+ * @param [in] maxNumBlocks  Number of blocks needed to cover the whole query.
+ *                           TODO: Calculate this directly from query, instead of passing it.
+ * @param [in] queryLength
+ * @param [in] target
+ * @param [in] targetLength
+ * @param [in] k
+ * @param [in] mode  EDLIB_MODE_HW or EDLIB_MODE_SHW
+ * @param [out] bestScore_  Edit distance.
+ * @param [out] positions_  Array of 0-indexed positions in target at which best score was found.
+                            Make sure to free this array with free().
+ * @param [out] numPositions_  Number of positions in the positions_ array.
+ * @return Status.
+ */
+static int myersCalcEditDistanceSemiGlobal(
+        const Word* const Peq, const int W, const int maxNumBlocks,
+        const int queryLength,
+        const unsigned char* const target, const int targetLength,
+        int k, const EdlibAlignMode mode,
+        int* const bestScore_, int** const positions_, int* const numPositions_) {
+    *positions_ = NULL;
+    *numPositions_ = 0;
+
+    // firstBlock is 0-based index of first block in Ukkonen band.
+    // lastBlock is 0-based index of last block in Ukkonen band.
+    int firstBlock = 0;
+    int lastBlock = min(ceilDiv(k + 1, WORD_SIZE), maxNumBlocks) - 1; // y in Myers
+    Block *bl; // Current block
+
+    Block* blocks = new Block[maxNumBlocks];
+
+    // For HW, solution will never be larger then queryLength.
+    if (mode == EDLIB_MODE_HW) {
+        k = min(queryLength, k);
+    }
+
+    // Each STRONG_REDUCE_NUM column is reduced in more expensive way.
+    // This gives speed up of about 2 times for small k.
+    const int STRONG_REDUCE_NUM = 2048;
+
+    // Initialize P, M and score
+    bl = blocks;
+    for (int b = 0; b <= lastBlock; b++) {
+        bl->score = (b + 1) * WORD_SIZE;
+        bl->P = static_cast<Word>(-1); // All 1s
+        bl->M = static_cast<Word>(0);
+        bl++;
+    }
+
+    int bestScore = -1;
+    vector<int> positions; // TODO: Maybe put this on heap?
+    const int startHout = mode == EDLIB_MODE_HW ? 0 : 1; // If 0 then gap before query is not penalized;
+    const unsigned char* targetChar = target;
+    for (int c = 0; c < targetLength; c++) { // for each column
+        const Word* Peq_c = Peq + (*targetChar) * maxNumBlocks;
+
+        //----------------------- Calculate column -------------------------//
+        int hout = startHout;
+        bl = blocks + firstBlock;
+        Peq_c += firstBlock;
+        for (int b = firstBlock; b <= lastBlock; b++) {
+            hout = calculateBlock(bl->P, bl->M, *Peq_c, hout, bl->P, bl->M);
+            bl->score += hout;
+            bl++; Peq_c++;
+        }
+        bl--; Peq_c--;
+        //------------------------------------------------------------------//
+
+        //---------- Adjust number of blocks according to Ukkonen ----------//
+        if ((lastBlock < maxNumBlocks - 1) && (bl->score - hout <= k) // bl is pointing to last block
+            && ((*(Peq_c + 1) & WORD_1) || hout < 0)) { // Peq_c is pointing to last block
+            // If score of left block is not too big, calculate one more block
+            lastBlock++; bl++; Peq_c++;
+            bl->P = static_cast<Word>(-1); // All 1s
+            bl->M = static_cast<Word>(0);
+            bl->score = (bl - 1)->score - hout + WORD_SIZE + calculateBlock(bl->P, bl->M, *Peq_c, hout, bl->P, bl->M);
+        } else {
+            while (lastBlock >= firstBlock && bl->score >= k + WORD_SIZE) {
+                lastBlock--; bl--; Peq_c--;
+            }
+        }
+
+        // Every some columns, do some expensive but also more efficient block reducing.
+        // This is important!
+        //
+        // Reduce the band by decreasing last block if possible.
+        if (c % STRONG_REDUCE_NUM == 0) {
+            while (lastBlock >= 0 && lastBlock >= firstBlock && allBlockCellsLarger(*bl, k)) {
+                lastBlock--; bl--; Peq_c--;
+            }
+        }
+        // For HW, even if all cells are > k, there still may be solution in next
+        // column because starting conditions at upper boundary are 0.
+        // That means that first block is always candidate for solution,
+        // and we can never end calculation before last column.
+        if (mode == EDLIB_MODE_HW && lastBlock == -1) {
+            lastBlock++; bl++; Peq_c++;
+        }
+
+        // Reduce band by increasing first block if possible. Not applicable to HW.
+        if (mode != EDLIB_MODE_HW) {
+            while (firstBlock <= lastBlock && blocks[firstBlock].score >= k + WORD_SIZE) {
+                firstBlock++;
+            }
+            if (c % STRONG_REDUCE_NUM == 0) { // Do strong reduction every some blocks
+                while (firstBlock <= lastBlock && allBlockCellsLarger(blocks[firstBlock], k)) {
+                    firstBlock++;
+                }
+            }
+        }
+
+        // If band stops to exist finish
+        if (lastBlock < firstBlock) {
+            *bestScore_ = bestScore;
+            if (bestScore != -1) {
+                *positions_ = static_cast<int *>(malloc(sizeof(int) * static_cast<int>(positions.size())));
+                *numPositions_ = static_cast<int>(positions.size());
+                copy(positions.begin(), positions.end(), *positions_);
+            }
+            delete[] blocks;
+            return EDLIB_STATUS_OK;
+        }
+        //------------------------------------------------------------------//
+
+        //------------------------- Update best score ----------------------//
+        if (lastBlock == maxNumBlocks - 1) {
+            int colScore = bl->score;
+            if (colScore <= k) { // Scores > k dont have correct values (so we cannot use them), but are certainly > k.
+                // NOTE: Score that I find in column c is actually score from column c-W
+                if (bestScore == -1 || colScore <= bestScore) {
+                    if (colScore != bestScore) {
+                        positions.clear();
+                        bestScore = colScore;
+                        // Change k so we will look only for equal or better
+                        // scores then the best found so far.
+                        k = bestScore;
+                    }
+                    positions.push_back(c - W);
+                }
+            }
+        }
+        //------------------------------------------------------------------//
+
+        targetChar++;
+    }
+
+
+    // Obtain results for last W columns from last column.
+    if (lastBlock == maxNumBlocks - 1) {
+        vector<int> blockScores = getBlockCellValues(*bl);
+        for (int i = 0; i < W; i++) {
+            int colScore = blockScores[i + 1];
+            if (colScore <= k && (bestScore == -1 || colScore <= bestScore)) {
+                if (colScore != bestScore) {
+                    positions.clear();
+                    k = bestScore = colScore;
+                }
+                positions.push_back(targetLength - W + i);
+            }
+        }
+    }
+
+    *bestScore_ = bestScore;
+    if (bestScore != -1) {
+        *positions_ = static_cast<int *>(malloc(sizeof(int) * static_cast<int>(positions.size())));
+        *numPositions_ = static_cast<int>(positions.size());
+        copy(positions.begin(), positions.end(), *positions_);
+    }
+
+    delete[] blocks;
+    return EDLIB_STATUS_OK;
+}
+
+
+/**
+ * Uses Myers' bit-vector algorithm to find edit distance for global(NW) alignment method.
+ * @param [in] Peq  Query profile.
+ * @param [in] W  Size of padding in last block.
+ *                TODO: Calculate this directly from query, instead of passing it.
+ * @param [in] maxNumBlocks  Number of blocks needed to cover the whole query.
+ *                           TODO: Calculate this directly from query, instead of passing it.
+ * @param [in] queryLength
+ * @param [in] target
+ * @param [in] targetLength
+ * @param [in] k
+ * @param [out] bestScore_  Edit distance.
+ * @param [out] position_  0-indexed position in target at which best score was found.
+ * @param [in] findAlignment  If true, whole matrix is remembered and alignment data is returned.
+ *                            Quadratic amount of memory is consumed.
+ * @param [out] alignData  Data needed for alignment traceback (for reconstruction of alignment).
+ *                         Set only if findAlignment is set to true, otherwise it is NULL.
+ *                         Make sure to free this array using delete[].
+ * @param [out] targetStopPosition  If set to -1, whole calculation is performed normally, as expected.
+ *         If set to p, calculation is performed up to position p in target (inclusive)
+ *         and column p is returned as the only column in alignData.
+ * @return Status.
+ */
+static int myersCalcEditDistanceNW(const Word* const Peq, const int W, const int maxNumBlocks,
+                                   const int queryLength,
+                                   const unsigned char* const target, const int targetLength,
+                                   int k, int* const bestScore_,
+                                   int* const position_, const bool findAlignment,
+                                   AlignmentData** const alignData, const int targetStopPosition) {
+    if (targetStopPosition > -1 && findAlignment) {
+        // They can not be both set at the same time!
+        return EDLIB_STATUS_ERROR;
+    }
+
+    // Each STRONG_REDUCE_NUM column is reduced in more expensive way.
+    const int STRONG_REDUCE_NUM = 2048; // TODO: Choose this number dinamically (based on query and target lengths?), so it does not affect speed of computation
+
+    if (k < abs(targetLength - queryLength)) {
+        *bestScore_ = *position_ = -1;
+        return EDLIB_STATUS_OK;
+    }
+
+    k = min(k, max(queryLength, targetLength));  // Upper bound for k
+
+    // firstBlock is 0-based index of first block in Ukkonen band.
+    // lastBlock is 0-based index of last block in Ukkonen band.
+    int firstBlock = 0;
+    // This is optimal now, by my formula.
+    int lastBlock = min(maxNumBlocks, ceilDiv(min(k, (k + queryLength - targetLength) / 2) + 1, WORD_SIZE)) - 1;
+    Block* bl; // Current block
+
+    Block* blocks = new Block[maxNumBlocks];
+
+    // Initialize P, M and score
+    bl = blocks;
+    for (int b = 0; b <= lastBlock; b++) {
+        bl->score = (b + 1) * WORD_SIZE;
+        bl->P = static_cast<Word>(-1); // All 1s
+        bl->M = static_cast<Word>(0);
+        bl++;
+    }
+
+    // If we want to find alignment, we have to store needed data.
+    if (findAlignment)
+        *alignData = new AlignmentData(maxNumBlocks, targetLength);
+    else if (targetStopPosition > -1)
+        *alignData = new AlignmentData(maxNumBlocks, 1);
+    else
+        *alignData = NULL;
+
+    const unsigned char* targetChar = target;
+    for (int c = 0; c < targetLength; c++) { // for each column
+        const Word* Peq_c = Peq + *targetChar * maxNumBlocks;
+
+        //----------------------- Calculate column -------------------------//
+        int hout = 1;
+        bl = blocks + firstBlock;
+        for (int b = firstBlock; b <= lastBlock; b++) {
+            hout = calculateBlock(bl->P, bl->M, Peq_c[b], hout, bl->P, bl->M);
+            bl->score += hout;
+            bl++;
+        }
+        bl--;
+        //------------------------------------------------------------------//
+        // bl now points to last block
+
+        // Update k. I do it only on end of column because it would slow calculation too much otherwise.
+        // NOTICE: I add W when in last block because it is actually result from W cells to the left and W cells up.
+        k = min(k, bl->score
+                + max(targetLength - c - 1, queryLength - ((1 + lastBlock) * WORD_SIZE - 1) - 1)
+                + (lastBlock == maxNumBlocks - 1 ? W : 0));
+
+        //---------- Adjust number of blocks according to Ukkonen ----------//
+        //--- Adjust last block ---//
+        // If block is not beneath band, calculate next block. Only next because others are certainly beneath band.
+        if (lastBlock + 1 < maxNumBlocks
+            && !(//score[lastBlock] >= k + WORD_SIZE ||  // NOTICE: this condition could be satisfied if above block also!
+                 ((lastBlock + 1) * WORD_SIZE - 1
+                  > k - bl->score + 2 * WORD_SIZE - 2 - targetLength + c + queryLength))) {
+            lastBlock++; bl++;
+            bl->P = static_cast<Word>(-1); // All 1s
+            bl->M = static_cast<Word>(0);
+            int newHout = calculateBlock(bl->P, bl->M, Peq_c[lastBlock], hout, bl->P, bl->M);
+            bl->score = (bl - 1)->score - hout + WORD_SIZE + newHout;
+            hout = newHout;
+        }
+
+        // While block is out of band, move one block up.
+        // NOTE: Condition used here is more loose than the one from the article, since I simplified the max() part of it.
+        // I could consider adding that max part, for optimal performance.
+        while (lastBlock >= firstBlock
+               && (bl->score >= k + WORD_SIZE
+                   || ((lastBlock + 1) * WORD_SIZE - 1 >
+                       // TODO: Does not work if do not put +1! Why???
+                       k - bl->score + 2 * WORD_SIZE - 2 - targetLength + c + queryLength + 1))) {
+            lastBlock--; bl--;
+        }
+        //-------------------------//
+
+        //--- Adjust first block ---//
+        // While outside of band, advance block
+        while (firstBlock <= lastBlock
+               && (blocks[firstBlock].score >= k + WORD_SIZE
+                   || ((firstBlock + 1) * WORD_SIZE - 1 <
+                       blocks[firstBlock].score - k - targetLength + queryLength + c))) {
+            firstBlock++;
+        }
+        //--------------------------/
+
+
+        // TODO: consider if this part is useful, it does not seem to help much
+        if (c % STRONG_REDUCE_NUM == 0) { // Every some columns do more expensive but more efficient reduction
+            while (lastBlock >= firstBlock) {
+                // If all cells outside of band, remove block
+                vector<int> scores = getBlockCellValues(*bl);
+                int numCells = lastBlock == maxNumBlocks - 1 ? WORD_SIZE - W : WORD_SIZE;
+                int r = lastBlock * WORD_SIZE + numCells - 1;
+                bool reduce = true;
+                for (int i = WORD_SIZE - numCells; i < WORD_SIZE; i++) {
+                    // TODO: Does not work if do not put +1! Why???
+                    if (scores[i] <= k && r <= k - scores[i] - targetLength + c + queryLength + 1) {
+                        reduce = false;
+                        break;
+                    }
+                    r--;
+                }
+                if (!reduce) break;
+                lastBlock--; bl--;
+            }
+
+            while (firstBlock <= lastBlock) {
+                // If all cells outside of band, remove block
+                vector<int> scores = getBlockCellValues(blocks[firstBlock]);
+                int numCells = firstBlock == maxNumBlocks - 1 ? WORD_SIZE - W : WORD_SIZE;
+                int r = firstBlock * WORD_SIZE + numCells - 1;
+                bool reduce = true;
+                for (int i = WORD_SIZE - numCells; i < WORD_SIZE; i++) {
+                    if (scores[i] <= k && r >= scores[i] - k - targetLength + c + queryLength) {
+                        reduce = false;
+                        break;
+                    }
+                    r--;
+                }
+                if (!reduce) break;
+                firstBlock++;
+            }
+        }
+
+
+        // If band stops to exist finish
+        if (lastBlock < firstBlock) {
+            *bestScore_ = *position_ = -1;
+            delete[] blocks;
+            return EDLIB_STATUS_OK;
+        }
+        //------------------------------------------------------------------//
+
+
+        //---- Save column so it can be used for reconstruction ----//
+        if (findAlignment && c < targetLength) {
+            bl = blocks + firstBlock;
+            for (int b = firstBlock; b <= lastBlock; b++) {
+                (*alignData)->Ps[maxNumBlocks * c + b] = bl->P;
+                (*alignData)->Ms[maxNumBlocks * c + b] = bl->M;
+                (*alignData)->scores[maxNumBlocks * c + b] = bl->score;
+                (*alignData)->firstBlocks[c] = firstBlock;
+                (*alignData)->lastBlocks[c] = lastBlock;
+                bl++;
+            }
+        }
+        //----------------------------------------------------------//
+        //---- If this is stop column, save it and finish ----//
+        if (c == targetStopPosition) {
+            for (int b = firstBlock; b <= lastBlock; b++) {
+                (*alignData)->Ps[b] = (blocks + b)->P;
+                (*alignData)->Ms[b] = (blocks + b)->M;
+                (*alignData)->scores[b] = (blocks + b)->score;
+                (*alignData)->firstBlocks[0] = firstBlock;
+                (*alignData)->lastBlocks[0] = lastBlock;
+            }
+            *bestScore_ = -1;
+            *position_ = targetStopPosition;
+            delete[] blocks;
+            return EDLIB_STATUS_OK;
+        }
+        //----------------------------------------------------//
+
+        targetChar++;
+    }
+
+    if (lastBlock == maxNumBlocks - 1) { // If last block of last column was calculated
+        // Obtain best score from block -> it is complicated because query is padded with W cells
+        int bestScore = getBlockCellValues(blocks[lastBlock])[W];
+        if (bestScore <= k) {
+            *bestScore_ = bestScore;
+            *position_ = targetLength - 1;
+            delete[] blocks;
+            return EDLIB_STATUS_OK;
+        }
+    }
+
+    *bestScore_ = *position_ = -1;
+    delete[] blocks;
+    return EDLIB_STATUS_OK;
+}
+
+
+/**
+ * Finds one possible alignment that gives optimal score by moving back through the dynamic programming matrix,
+ * that is stored in alignData. Consumes large amount of memory: O(queryLength * targetLength).
+ * @param [in] queryLength  Normal length, without W.
+ * @param [in] targetLength  Normal length, without W.
+ * @param [in] bestScore  Best score.
+ * @param [in] alignData  Data obtained during finding best score that is useful for finding alignment.
+ * @param [out] alignment  Alignment.
+ * @param [out] alignmentLength  Length of alignment.
+ * @return Status code.
+ */
+static int obtainAlignmentTraceback(const int queryLength, const int targetLength,
+                                    const int bestScore, const AlignmentData* const alignData,
+                                    unsigned char** const alignment, int* const alignmentLength) {
+    const int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
+    const int W = maxNumBlocks * WORD_SIZE - queryLength;
+
+    *alignment = static_cast<unsigned char*>(malloc((queryLength + targetLength - 1) * sizeof(unsigned char)));
+    *alignmentLength = 0;
+    int c = targetLength - 1; // index of column
+    int b = maxNumBlocks - 1; // index of block in column
+    int currScore = bestScore; // Score of current cell
+    int lScore  = -1; // Score of left cell
+    int uScore  = -1; // Score of upper cell
+    int ulScore = -1; // Score of upper left cell
+    Word currP = alignData->Ps[c * maxNumBlocks + b]; // P of current block
+    Word currM = alignData->Ms[c * maxNumBlocks + b]; // M of current block
+    // True if block to left exists and is in band
+    bool thereIsLeftBlock = c > 0 && b >= alignData->firstBlocks[c-1] && b <= alignData->lastBlocks[c-1];
+    // We set initial values of lP and lM to 0 only to avoid compiler warnings, they should not affect the
+    // calculation as both lP and lM should be initialized at some moment later (but compiler can not
+    // detect it since this initialization is guaranteed by "business" logic).
+    Word lP = 0, lM = 0;
+    if (thereIsLeftBlock) {
+        lP = alignData->Ps[(c - 1) * maxNumBlocks + b]; // P of block to the left
+        lM = alignData->Ms[(c - 1) * maxNumBlocks + b]; // M of block to the left
+    }
+    currP <<= W;
+    currM <<= W;
+    int blockPos = WORD_SIZE - W - 1; // 0 based index of current cell in blockPos
+
+    // TODO(martin): refactor this whole piece of code. There are too many if-else statements,
+    // it is too easy for a bug to hide and to hard to effectively cover all the edge-cases.
+    // We need better separation of logic and responsibilities.
+    while (true) {
+        if (c == 0) {
+            thereIsLeftBlock = true;
+            lScore = b * WORD_SIZE + blockPos + 1;
+            ulScore = lScore - 1;
+        }
+
+        // TODO: improvement: calculate only those cells that are needed,
+        //       for example if I calculate upper cell and can move up,
+        //       there is no need to calculate left and upper left cell
+        //---------- Calculate scores ---------//
+        if (lScore == -1 && thereIsLeftBlock) {
+            lScore = alignData->scores[(c - 1) * maxNumBlocks + b]; // score of block to the left
+            for (int i = 0; i < WORD_SIZE - blockPos - 1; i++) {
+                if (lP & HIGH_BIT_MASK) lScore--;
+                if (lM & HIGH_BIT_MASK) lScore++;
+                lP <<= 1;
+                lM <<= 1;
+            }
+        }
+        if (ulScore == -1) {
+            if (lScore != -1) {
+                ulScore = lScore;
+                if (lP & HIGH_BIT_MASK) ulScore--;
+                if (lM & HIGH_BIT_MASK) ulScore++;
+            }
+            else if (c > 0 && b-1 >= alignData->firstBlocks[c-1] && b-1 <= alignData->lastBlocks[c-1]) {
+                // This is the case when upper left cell is last cell in block,
+                // and block to left is not in band so lScore is -1.
+                ulScore = alignData->scores[(c - 1) * maxNumBlocks + b - 1];
+            }
+        }
+        if (uScore == -1) {
+            uScore = currScore;
+            if (currP & HIGH_BIT_MASK) uScore--;
+            if (currM & HIGH_BIT_MASK) uScore++;
+            currP <<= 1;
+            currM <<= 1;
+        }
+        //-------------------------------------//
+
+        // TODO: should I check if there is upper block?
+
+        //-------------- Move --------------//
+        // Move up - insertion to target - deletion from query
+        if (uScore != -1 && uScore + 1 == currScore) {
+            currScore = uScore;
+            lScore = ulScore;
+            uScore = ulScore = -1;
+            if (blockPos == 0) { // If entering new (upper) block
+                if (b == 0) { // If there are no cells above (only boundary cells)
+                    (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_INSERT; // Move up
+                    for (int i = 0; i < c + 1; i++) // Move left until end
+                        (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_DELETE;
+                    break;
+                } else {
+                    blockPos = WORD_SIZE - 1;
+                    b--;
+                    currP = alignData->Ps[c * maxNumBlocks + b];
+                    currM = alignData->Ms[c * maxNumBlocks + b];
+                    if (c > 0 && b >= alignData->firstBlocks[c-1] && b <= alignData->lastBlocks[c-1]) {
+                        thereIsLeftBlock = true;
+                        lP = alignData->Ps[(c - 1) * maxNumBlocks + b]; // TODO: improve this, too many operations
+                        lM = alignData->Ms[(c - 1) * maxNumBlocks + b];
+                    } else {
+                        thereIsLeftBlock = false;
+                        // TODO(martin): There may not be left block, but there can be left boundary - do we
+                        // handle this correctly then? Are l and ul score set correctly? I should check that / refactor this.
+                    }
+                }
+            } else {
+                blockPos--;
+                lP <<= 1;
+                lM <<= 1;
+            }
+            // Mark move
+            (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_INSERT;
+        }
+        // Move left - deletion from target - insertion to query
+        else if (lScore != -1 && lScore + 1 == currScore) {
+            currScore = lScore;
+            uScore = ulScore;
+            lScore = ulScore = -1;
+            c--;
+            if (c == -1) { // If there are no cells to the left (only boundary cells)
+                (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_DELETE; // Move left
+                int numUp = b * WORD_SIZE + blockPos + 1;
+                for (int i = 0; i < numUp; i++) // Move up until end
+                    (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_INSERT;
+                break;
+            }
+            currP = lP;
+            currM = lM;
+            if (c > 0 && b >= alignData->firstBlocks[c-1] && b <= alignData->lastBlocks[c-1]) {
+                thereIsLeftBlock = true;
+                lP = alignData->Ps[(c - 1) * maxNumBlocks + b];
+                lM = alignData->Ms[(c - 1) * maxNumBlocks + b];
+            } else {
+                if (c == 0) { // If there are no cells to the left (only boundary cells)
+                    thereIsLeftBlock = true;
+                    lScore = b * WORD_SIZE + blockPos + 1;
+                    ulScore = lScore - 1;
+                } else {
+                    thereIsLeftBlock = false;
+                }
+            }
+            // Mark move
+            (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_DELETE;
+        }
+        // Move up left - (mis)match
+        else if (ulScore != -1) {
+            unsigned char moveCode = ulScore == currScore ? EDLIB_EDOP_MATCH : EDLIB_EDOP_MISMATCH;
+            currScore = ulScore;
+            uScore = lScore = ulScore = -1;
+            c--;
+            if (c == -1) { // If there are no cells to the left (only boundary cells)
+                (*alignment)[(*alignmentLength)++] = moveCode; // Move left
+                int numUp = b * WORD_SIZE + blockPos;
+                for (int i = 0; i < numUp; i++) // Move up until end
+                    (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_INSERT;
+                break;
+            }
+            if (blockPos == 0) { // If entering upper left block
+                if (b == 0) { // If there are no more cells above (only boundary cells)
+                    (*alignment)[(*alignmentLength)++] = moveCode; // Move up left
+                    for (int i = 0; i < c + 1; i++) // Move left until end
+                        (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_DELETE;
+                    break;
+                }
+                blockPos = WORD_SIZE - 1;
+                b--;
+                currP = alignData->Ps[c * maxNumBlocks + b];
+                currM = alignData->Ms[c * maxNumBlocks + b];
+            } else { // If entering left block
+                blockPos--;
+                currP = lP;
+                currM = lM;
+                currP <<= 1;
+                currM <<= 1;
+            }
+            // Set new left block
+            if (c > 0 && b >= alignData->firstBlocks[c-1] && b <= alignData->lastBlocks[c-1]) {
+                thereIsLeftBlock = true;
+                lP = alignData->Ps[(c - 1) * maxNumBlocks + b];
+                lM = alignData->Ms[(c - 1) * maxNumBlocks + b];
+            } else {
+                if (c == 0) { // If there are no cells to the left (only boundary cells)
+                    thereIsLeftBlock = true;
+                    lScore = b * WORD_SIZE + blockPos + 1;
+                    ulScore = lScore - 1;
+                } else {
+                    thereIsLeftBlock = false;
+                }
+            }
+            // Mark move
+            (*alignment)[(*alignmentLength)++] = moveCode;
+        } else {
+            // Reached end - finished!
+            break;
+        }
+        //----------------------------------//
+    }
+
+    *alignment = static_cast<unsigned char*>(realloc(*alignment, (*alignmentLength) * sizeof(unsigned char)));
+    reverse(*alignment, *alignment + (*alignmentLength));
+    return EDLIB_STATUS_OK;
+}
+
+
+/**
+ * Finds one possible alignment that gives optimal score (bestScore).
+ * It will split problem into smaller problems using Hirschberg's algorithm and when they are small enough,
+ * it will solve them using traceback algorithm.
+ * @param [in] query
+ * @param [in] rQuery  Reversed query.
+ * @param [in] queryLength
+ * @param [in] target
+ * @param [in] rTarget  Reversed target.
+ * @param [in] targetLength
+ * @param [in] equalityDefinition
+ * @param [in] alphabetLength
+ * @param [in] bestScore  Best(optimal) score.
+ * @param [out] alignment  Sequence of edit operations that make target equal to query.
+ * @param [out] alignmentLength  Length of alignment.
+ * @return Status code.
+ */
+static int obtainAlignment(
+        const unsigned char* const query, const unsigned char* const rQuery, const int queryLength,
+        const unsigned char* const target, const unsigned char* const rTarget, const int targetLength,
+        const EqualityDefinition& equalityDefinition, const int alphabetLength, const int bestScore,
+        unsigned char** const alignment, int* const alignmentLength) {
+
+    // Handle special case when one of sequences has length of 0.
+    if (queryLength == 0 || targetLength == 0) {
+        *alignmentLength = targetLength + queryLength;
+        *alignment = static_cast<unsigned char*>(malloc((*alignmentLength) * sizeof(unsigned char)));
+        for (int i = 0; i < *alignmentLength; i++) {
+            (*alignment)[i] = queryLength == 0 ? EDLIB_EDOP_DELETE : EDLIB_EDOP_INSERT;
+        }
+        return EDLIB_STATUS_OK;
+    }
+
+    const int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
+    const int W = maxNumBlocks * WORD_SIZE - queryLength;
+    int statusCode;
+
+    // TODO: think about reducing number of memory allocations in alignment functions, probably
+    // by sharing some memory that is allocated only once. That refers to: Peq, columns in Hirschberg,
+    // and it could also be done for alignments - we could have one big array for alignment that would be
+    // sparsely populated by each of steps in recursion, and at the end we would just consolidate those results.
+
+    // If estimated memory consumption for traceback algorithm is smaller than 1MB use it,
+    // otherwise use Hirschberg's algorithm. By running few tests I choose boundary of 1MB as optimal.
+    long long alignmentDataSize = (2ll * sizeof(Word) + sizeof(int)) * maxNumBlocks * targetLength
+        + 2ll * sizeof(int) * targetLength;
+    if (alignmentDataSize < 1024 * 1024) {
+        int score_, endLocation_;  // Used only to call function.
+        AlignmentData* alignData = NULL;
+        Word* Peq = buildPeq(alphabetLength, query, queryLength, equalityDefinition);
+        myersCalcEditDistanceNW(Peq, W, maxNumBlocks,
+                                queryLength,
+                                target, targetLength,
+                                bestScore,
+                                &score_, &endLocation_, true, &alignData, -1);
+        //assert(score_ == bestScore);
+        //assert(endLocation_ == targetLength - 1);
+
+        statusCode = obtainAlignmentTraceback(queryLength, targetLength,
+                                              bestScore, alignData, alignment, alignmentLength);
+        delete alignData;
+        delete[] Peq;
+    } else {
+        statusCode = obtainAlignmentHirschberg(query, rQuery, queryLength,
+                                               target, rTarget, targetLength,
+                                               equalityDefinition, alphabetLength, bestScore,
+                                               alignment, alignmentLength);
+    }
+    return statusCode;
+}
+
+
+/**
+ * Finds one possible alignment that gives optimal score (bestScore).
+ * Uses Hirschberg's algorithm to split problem into two sub-problems, solve them and combine them together.
+ * @param [in] query
+ * @param [in] rQuery  Reversed query.
+ * @param [in] queryLength
+ * @param [in] target
+ * @param [in] rTarget  Reversed target.
+ * @param [in] targetLength
+ * @param [in] alphabetLength
+ * @param [in] bestScore  Best(optimal) score.
+ * @param [out] alignment  Sequence of edit operations that make target equal to query.
+ * @param [out] alignmentLength  Length of alignment.
+ * @return Status code.
+ */
+static int obtainAlignmentHirschberg(
+        const unsigned char* const query, const unsigned char* const rQuery, const int queryLength,
+        const unsigned char* const target, const unsigned char* const rTarget, const int targetLength,
+        const EqualityDefinition& equalityDefinition, const int alphabetLength, const int bestScore,
+        unsigned char** const alignment, int* const alignmentLength) {
+
+    const int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
+    const int W = maxNumBlocks * WORD_SIZE - queryLength;
+
+    Word* Peq = buildPeq(alphabetLength, query, queryLength, equalityDefinition);
+    Word* rPeq = buildPeq(alphabetLength, rQuery, queryLength, equalityDefinition);
+
+    // Used only to call functions.
+    int score_, endLocation_;
+
+    // Divide dynamic matrix into two halfs, left and right.
+    const int leftHalfWidth = targetLength / 2;
+    const int rightHalfWidth = targetLength - leftHalfWidth;
+
+    // Calculate left half.
+    AlignmentData* alignDataLeftHalf = NULL;
+    int leftHalfCalcStatus = myersCalcEditDistanceNW(
+            Peq, W, maxNumBlocks, queryLength, target, targetLength, bestScore,
+            &score_, &endLocation_, false, &alignDataLeftHalf, leftHalfWidth - 1);
+
+    // Calculate right half.
+    AlignmentData* alignDataRightHalf = NULL;
+    int rightHalfCalcStatus = myersCalcEditDistanceNW(
+            rPeq, W, maxNumBlocks, queryLength, rTarget, targetLength, bestScore,
+            &score_, &endLocation_, false, &alignDataRightHalf, rightHalfWidth - 1);
+
+    delete[] Peq;
+    delete[] rPeq;
+
+    if (leftHalfCalcStatus == EDLIB_STATUS_ERROR || rightHalfCalcStatus == EDLIB_STATUS_ERROR) {
+        if (alignDataLeftHalf) delete alignDataLeftHalf;
+        if (alignDataRightHalf) delete alignDataRightHalf;
+        return EDLIB_STATUS_ERROR;
+    }
+
+    // Unwrap the left half.
+    int firstBlockIdxLeft = alignDataLeftHalf->firstBlocks[0];
+    int lastBlockIdxLeft = alignDataLeftHalf->lastBlocks[0];
+    // TODO: avoid this allocation by using some shared array?
+    // scoresLeft contains scores from left column, starting with scoresLeftStartIdx row (query index)
+    // and ending with scoresLeftEndIdx row (0-indexed).
+    int scoresLeftLength = (lastBlockIdxLeft - firstBlockIdxLeft + 1) * WORD_SIZE;
+    int* scoresLeft = new int[scoresLeftLength];
+    for (int blockIdx = firstBlockIdxLeft; blockIdx <= lastBlockIdxLeft; blockIdx++) {
+        Block block(alignDataLeftHalf->Ps[blockIdx], alignDataLeftHalf->Ms[blockIdx],
+                    alignDataLeftHalf->scores[blockIdx]);
+        readBlock(block, scoresLeft + (blockIdx - firstBlockIdxLeft) * WORD_SIZE);
+    }
+    int scoresLeftStartIdx = firstBlockIdxLeft * WORD_SIZE;
+    // If last block contains padding, shorten the length of scores for the length of padding.
+    if (lastBlockIdxLeft == maxNumBlocks - 1) {
+        scoresLeftLength -= W;
+    }
+
+    // Unwrap the right half (I also reverse it while unwraping).
+    int firstBlockIdxRight = alignDataRightHalf->firstBlocks[0];
+    int lastBlockIdxRight = alignDataRightHalf->lastBlocks[0];
+    int scoresRightLength = (lastBlockIdxRight - firstBlockIdxRight + 1) * WORD_SIZE;
+    int* scoresRight = new int[scoresRightLength];
+    int* scoresRightOriginalStart = scoresRight;
+    for (int blockIdx = firstBlockIdxRight; blockIdx <= lastBlockIdxRight; blockIdx++) {
+        Block block(alignDataRightHalf->Ps[blockIdx], alignDataRightHalf->Ms[blockIdx],
+                    alignDataRightHalf->scores[blockIdx]);
+        readBlockReverse(block, scoresRight + (lastBlockIdxRight - blockIdx) * WORD_SIZE);
+    }
+    int scoresRightStartIdx = queryLength - (lastBlockIdxRight + 1) * WORD_SIZE;
+    // If there is padding at the beginning of scoresRight (that can happen because of reversing that we do),
+    // move pointer forward to remove the padding (that is why we remember originalStart).
+    if (scoresRightStartIdx < 0) {
+        //assert(scoresRightStartIdx == -1 * W);
+        scoresRight += W;
+        scoresRightStartIdx += W;
+        scoresRightLength -= W;
+    }
+
+    delete alignDataLeftHalf;
+    delete alignDataRightHalf;
+
+    //--------------------- Find the best move ----------------//
+    // Find the query/row index of cell in left column which together with its lower right neighbour
+    // from right column gives the best score (when summed). We also have to consider boundary cells
+    // (those cells at -1 indexes).
+    //  x|
+    //  -+-
+    //   |x
+    int queryIdxLeftStart = max(scoresLeftStartIdx, scoresRightStartIdx - 1);
+    int queryIdxLeftEnd = min(scoresLeftStartIdx + scoresLeftLength - 1,
+                          scoresRightStartIdx + scoresRightLength - 2);
+    int leftScore = -1, rightScore = -1;
+    int queryIdxLeftAlignment = -1;  // Query/row index of cell in left column where alignment is passing through.
+    bool queryIdxLeftAlignmentFound = false;
+    for (int queryIdx = queryIdxLeftStart; queryIdx <= queryIdxLeftEnd; queryIdx++) {
+        leftScore = scoresLeft[queryIdx - scoresLeftStartIdx];
+        rightScore = scoresRight[queryIdx + 1 - scoresRightStartIdx];
+        if (leftScore + rightScore == bestScore) {
+            queryIdxLeftAlignment = queryIdx;
+            queryIdxLeftAlignmentFound = true;
+            break;
+        }
+    }
+    // Check boundary cells.
+    if (!queryIdxLeftAlignmentFound && scoresLeftStartIdx == 0 && scoresRightStartIdx == 0) {
+        leftScore = leftHalfWidth;
+        rightScore = scoresRight[0];
+        if (leftScore + rightScore == bestScore) {
+            queryIdxLeftAlignment = -1;
+            queryIdxLeftAlignmentFound = true;
+        }
+    }
+    if (!queryIdxLeftAlignmentFound && scoresLeftStartIdx + scoresLeftLength == queryLength
+        && scoresRightStartIdx + scoresRightLength == queryLength) {
+        leftScore = scoresLeft[scoresLeftLength - 1];
+        rightScore = rightHalfWidth;
+        if (leftScore + rightScore == bestScore) {
+            queryIdxLeftAlignment = queryLength - 1;
+            queryIdxLeftAlignmentFound = true;
+        }
+    }
+
+    delete[] scoresLeft;
+    delete[] scoresRightOriginalStart;
+
+    if (queryIdxLeftAlignmentFound == false) {
+        // If there was no move that is part of optimal alignment, then there is no such alignment
+        // or given bestScore is not correct!
+        return EDLIB_STATUS_ERROR;
+    }
+    //----------------------------------------------------------//
+
+    // Calculate alignments for upper half of left half (upper left - ul)
+    // and lower half of right half (lower right - lr).
+    const int ulHeight = queryIdxLeftAlignment + 1;
+    const int lrHeight = queryLength - ulHeight;
+    const int ulWidth = leftHalfWidth;
+    const int lrWidth = rightHalfWidth;
+    unsigned char* ulAlignment = NULL; int ulAlignmentLength;
+    int ulStatusCode = obtainAlignment(query, rQuery + lrHeight, ulHeight,
+                                       target, rTarget + lrWidth, ulWidth,
+                                       equalityDefinition, alphabetLength, leftScore,
+                                       &ulAlignment, &ulAlignmentLength);
+    unsigned char* lrAlignment = NULL; int lrAlignmentLength;
+    int lrStatusCode = obtainAlignment(query + ulHeight, rQuery, lrHeight,
+                                       target + ulWidth, rTarget, lrWidth,
+                                       equalityDefinition, alphabetLength, rightScore,
+                                       &lrAlignment, &lrAlignmentLength);
+    if (ulStatusCode == EDLIB_STATUS_ERROR || lrStatusCode == EDLIB_STATUS_ERROR) {
+        if (ulAlignment) free(ulAlignment);
+        if (lrAlignment) free(lrAlignment);
+        return EDLIB_STATUS_ERROR;
+    }
+
+    // Build alignment by concatenating upper left alignment with lower right alignment.
+    *alignmentLength = ulAlignmentLength + lrAlignmentLength;
+    *alignment = static_cast<unsigned char*>(malloc((*alignmentLength) * sizeof(unsigned char)));
+    memcpy(*alignment, ulAlignment, ulAlignmentLength);
+    memcpy(*alignment + ulAlignmentLength, lrAlignment, lrAlignmentLength);
+
+    free(ulAlignment);
+    free(lrAlignment);
+    return EDLIB_STATUS_OK;
+}
+
+
+/**
+ * Takes char query and char target, recognizes alphabet and transforms them into unsigned char sequences
+ * where elements in sequences are not any more letters of alphabet, but their index in alphabet.
+ * Most of internal edlib functions expect such transformed sequences.
+ * This function will allocate queryTransformed and targetTransformed, so make sure to free them when done.
+ * Example:
+ *   Original sequences: "ACT" and "CGT".
+ *   Alphabet would be recognized as "ACTG". Alphabet length = 4.
+ *   Transformed sequences: [0, 1, 2] and [1, 3, 2].
+ * @param [in] queryOriginal
+ * @param [in] queryLength
+ * @param [in] targetOriginal
+ * @param [in] targetLength
+ * @param [out] queryTransformed  It will contain values in range [0, alphabet length - 1].
+ * @param [out] targetTransformed  It will contain values in range [0, alphabet length - 1].
+ * @return  Alphabet as a string of unique characters, where index of each character is its value in transformed
+ *          sequences.
+ */
+static string transformSequences(const char* const queryOriginal, const int queryLength,
+                                 const char* const targetOriginal, const int targetLength,
+                                 unsigned char** const queryTransformed,
+                                 unsigned char** const targetTransformed) {
+    // Alphabet is constructed from letters that are present in sequences.
+    // Each letter is assigned an ordinal number, starting from 0 up to alphabetLength - 1,
+    // and new query and target are created in which letters are replaced with their ordinal numbers.
+    // This query and target are used in all the calculations later.
+    *queryTransformed = static_cast<unsigned char *>(malloc(sizeof(unsigned char) * queryLength));
+    *targetTransformed = static_cast<unsigned char *>(malloc(sizeof(unsigned char) * targetLength));
+
+    string alphabet = "";
+
+    // Alphabet information, it is constructed on fly while transforming sequences.
+    // letterIdx[c] is index of letter c in alphabet.
+    unsigned char letterIdx[MAX_UCHAR + 1];
+    bool inAlphabet[MAX_UCHAR + 1]; // inAlphabet[c] is true if c is in alphabet
+    for (int i = 0; i < MAX_UCHAR + 1; i++) inAlphabet[i] = false;
+
+    for (int i = 0; i < queryLength; i++) {
+        unsigned char c = static_cast<unsigned char>(queryOriginal[i]);
+        if (!inAlphabet[c]) {
+            inAlphabet[c] = true;
+            letterIdx[c] = static_cast<unsigned char>(alphabet.size());
+            alphabet += queryOriginal[i];
+        }
+        (*queryTransformed)[i] = letterIdx[c];
+    }
+    for (int i = 0; i < targetLength; i++) {
+        unsigned char c = static_cast<unsigned char>(targetOriginal[i]);
+        if (!inAlphabet[c]) {
+            inAlphabet[c] = true;
+            letterIdx[c] = static_cast<unsigned char>(alphabet.size());
+            alphabet += targetOriginal[i];
+        }
+        (*targetTransformed)[i] = letterIdx[c];
+    }
+
+    return alphabet;
+}
+
+
+extern "C" EdlibAlignConfig edlibNewAlignConfig(int k, EdlibAlignMode mode, EdlibAlignTask task,
+                                                const EdlibEqualityPair* additionalEqualities,
+                                                int additionalEqualitiesLength) {
+    EdlibAlignConfig config;
+    config.k = k;
+    config.mode = mode;
+    config.task = task;
+    config.additionalEqualities = additionalEqualities;
+    config.additionalEqualitiesLength = additionalEqualitiesLength;
+    return config;
+}
+
+extern "C" EdlibAlignConfig edlibDefaultAlignConfig(void) {
+    return edlibNewAlignConfig(-1, EDLIB_MODE_NW, EDLIB_TASK_DISTANCE, NULL, 0);
+}
+
+extern "C" void edlibFreeAlignResult(EdlibAlignResult result) {
+    if (result.endLocations) free(result.endLocations);
+    if (result.startLocations) free(result.startLocations);
+    if (result.alignment) free(result.alignment);
+}

--- a/textsearch/csrc/edlib.cc
+++ b/textsearch/csrc/edlib.cc
@@ -1,446 +1,482 @@
-#include "edlib.h"
+// Copy from
+// https://github.com/Martinsos/edlib/blob/master/edlib/src/edlib.cpp
+//
+#include "textsearch/csrc/edlib.h"
 
-#include <stdint.h>
-#include <cstdlib>
 #include <algorithm>
-#include <vector>
+#include <cstdlib>
 #include <cstring>
+#include <stdint.h>
 #include <string>
+#include <vector>
 
 using namespace std;
 
 typedef uint64_t Word;
 static const int WORD_SIZE = sizeof(Word) * 8; // Size of Word in bits
 static const Word WORD_1 = static_cast<Word>(1);
-static const Word HIGH_BIT_MASK = WORD_1 << (WORD_SIZE - 1);  // 100..00
+static const Word HIGH_BIT_MASK = WORD_1 << (WORD_SIZE - 1); // 100..00
 static const int MAX_UCHAR = 255;
 
 // Data needed to find alignment.
 struct AlignmentData {
-    Word* Ps;
-    Word* Ms;
-    int* scores;
-    int* firstBlocks;
-    int* lastBlocks;
+  Word *Ps;
+  Word *Ms;
+  int *scores;
+  int *firstBlocks;
+  int *lastBlocks;
 
-    AlignmentData(int maxNumBlocks, int targetLength) {
-        // We build a complete table and mark first and last block for each column
-        // (because algorithm is banded so only part of each columns is used).
-        // TODO: do not build a whole table, but just enough blocks for each column.
-         Ps     = new Word[maxNumBlocks * targetLength];
-         Ms     = new Word[maxNumBlocks * targetLength];
-         scores = new  int[maxNumBlocks * targetLength];
-         firstBlocks = new int[targetLength];
-         lastBlocks  = new int[targetLength];
-    }
+  AlignmentData(int maxNumBlocks, int targetLength) {
+    // We build a complete table and mark first and last block for each column
+    // (because algorithm is banded so only part of each columns is used).
+    // TODO: do not build a whole table, but just enough blocks for each column.
+    Ps = new Word[maxNumBlocks * targetLength];
+    Ms = new Word[maxNumBlocks * targetLength];
+    scores = new int[maxNumBlocks * targetLength];
+    firstBlocks = new int[targetLength];
+    lastBlocks = new int[targetLength];
+  }
 
-    ~AlignmentData() {
-        delete[] Ps;
-        delete[] Ms;
-        delete[] scores;
-        delete[] firstBlocks;
-        delete[] lastBlocks;
-    }
+  ~AlignmentData() {
+    delete[] Ps;
+    delete[] Ms;
+    delete[] scores;
+    delete[] firstBlocks;
+    delete[] lastBlocks;
+  }
 };
 
 struct Block {
-    Word P;  // Pvin
-    Word M;  // Mvin
-    int score; // score of last cell in block;
+  Word P;    // Pvin
+  Word M;    // Mvin
+  int score; // score of last cell in block;
 
-    Block() {}
-    Block(Word p, Word m, int s) :P(p), M(m), score(s) {}
+  Block() {}
+  Block(Word p, Word m, int s) : P(p), M(m), score(s) {}
 };
-
 
 /**
  * Defines equality relation on alphabet characters.
- * By default each character is always equal only to itself, but you can also provide additional equalities.
+ * By default each character is always equal only to itself, but you can also
+ * provide additional equalities.
  */
 class EqualityDefinition {
 private:
-    bool matrix[MAX_UCHAR + 1][MAX_UCHAR + 1];
-public:
-    EqualityDefinition(const string& alphabet,
-                       const EdlibEqualityPair* additionalEqualities = NULL,
-                       const int additionalEqualitiesLength = 0) {
-        for (int i = 0; i < static_cast<int>(alphabet.size()); i++) {
-            for (int j = 0; j < static_cast<int>(alphabet.size()); j++) {
-                matrix[i][j] = (i == j);
-            }
-        }
-        if (additionalEqualities != NULL) {
-            for (int i = 0; i < additionalEqualitiesLength; i++) {
-                size_t firstTransformed = alphabet.find(additionalEqualities[i].first);
-                size_t secondTransformed = alphabet.find(additionalEqualities[i].second);
-                if (firstTransformed != string::npos && secondTransformed != string::npos) {
-                    matrix[firstTransformed][secondTransformed] = matrix[secondTransformed][firstTransformed] = true;
-                }
-            }
-        }
-    }
+  bool matrix[MAX_UCHAR + 1][MAX_UCHAR + 1];
 
-    /**
-     * @param a  Element from transformed sequence.
-     * @param b  Element from transformed sequence.
-     * @return True if a and b are defined as equal, false otherwise.
-     */
-    bool areEqual(unsigned char a, unsigned char b) const {
-        return matrix[a][b];
+public:
+  EqualityDefinition(const string &alphabet,
+                     const EdlibEqualityPair *additionalEqualities = NULL,
+                     const int additionalEqualitiesLength = 0) {
+    for (int i = 0; i < static_cast<int>(alphabet.size()); i++) {
+      for (int j = 0; j < static_cast<int>(alphabet.size()); j++) {
+        matrix[i][j] = (i == j);
+      }
     }
+    if (additionalEqualities != NULL) {
+      for (int i = 0; i < additionalEqualitiesLength; i++) {
+        size_t firstTransformed = alphabet.find(additionalEqualities[i].first);
+        size_t secondTransformed =
+            alphabet.find(additionalEqualities[i].second);
+        if (firstTransformed != string::npos &&
+            secondTransformed != string::npos) {
+          matrix[firstTransformed][secondTransformed] =
+              matrix[secondTransformed][firstTransformed] = true;
+        }
+      }
+    }
+  }
+
+  /**
+   * @param a  Element from transformed sequence.
+   * @param b  Element from transformed sequence.
+   * @return True if a and b are defined as equal, false otherwise.
+   */
+  bool areEqual(unsigned char a, unsigned char b) const { return matrix[a][b]; }
 };
 
-static int myersCalcEditDistanceSemiGlobal(const Word* Peq, int W, int maxNumBlocks,
-                                           int queryLength,
-                                           const unsigned char* target, int targetLength,
-                                           int k, EdlibAlignMode mode,
-                                           int* bestScore_, int** positions_, int* numPositions_);
+static int myersCalcEditDistanceSemiGlobal(
+    const Word *Peq, int W, int maxNumBlocks, int queryLength,
+    const unsigned char *target, int targetLength, int k, EdlibAlignMode mode,
+    int *bestScore_, int **positions_, int *numPositions_);
 
-static int myersCalcEditDistanceNW(const Word* Peq, int W, int maxNumBlocks,
-                                   int queryLength,
-                                   const unsigned char* target, int targetLength,
-                                   int k, int* bestScore_,
-                                   int* position_, bool findAlignment,
-                                   AlignmentData** alignData, int targetStopPosition);
+static int myersCalcEditDistanceNW(const Word *Peq, int W, int maxNumBlocks,
+                                   int queryLength, const unsigned char *target,
+                                   int targetLength, int k, int *bestScore_,
+                                   int *position_, bool findAlignment,
+                                   AlignmentData **alignData,
+                                   int targetStopPosition);
 
-
-static int obtainAlignment(
-        const unsigned char* query, const unsigned char* rQuery, int queryLength,
-        const unsigned char* target, const unsigned char* rTarget, int targetLength,
-        const EqualityDefinition& equalityDefinition, int alphabetLength, int bestScore,
-        unsigned char** alignment, int* alignmentLength);
+static int obtainAlignment(const unsigned char *query,
+                           const unsigned char *rQuery, int queryLength,
+                           const unsigned char *target,
+                           const unsigned char *rTarget, int targetLength,
+                           const EqualityDefinition &equalityDefinition,
+                           int alphabetLength, int bestScore,
+                           unsigned char **alignment, int *alignmentLength);
 
 static int obtainAlignmentHirschberg(
-        const unsigned char* query, const unsigned char* rQuery, int queryLength,
-        const unsigned char* target, const unsigned char* rTarget, int targetLength,
-        const EqualityDefinition& equalityDefinition, int alphabetLength, int bestScore,
-        unsigned char** alignment, int* alignmentLength);
+    const unsigned char *query, const unsigned char *rQuery, int queryLength,
+    const unsigned char *target, const unsigned char *rTarget, int targetLength,
+    const EqualityDefinition &equalityDefinition, int alphabetLength,
+    int bestScore, unsigned char **alignment, int *alignmentLength);
 
 static int obtainAlignmentTraceback(int queryLength, int targetLength,
-                                    int bestScore, const AlignmentData* alignData,
-                                    unsigned char** alignment, int* alignmentLength);
+                                    int bestScore,
+                                    const AlignmentData *alignData,
+                                    unsigned char **alignment,
+                                    int *alignmentLength);
 
-static string transformSequences(const char* queryOriginal, int queryLength,
-                                 const char* targetOriginal, int targetLength,
-                                 unsigned char** queryTransformed,
-                                 unsigned char** targetTransformed);
+static string transformSequences(const char *queryOriginal, int queryLength,
+                                 const char *targetOriginal, int targetLength,
+                                 unsigned char **queryTransformed,
+                                 unsigned char **targetTransformed);
 
 static inline int ceilDiv(int x, int y);
 
-static inline unsigned char* createReverseCopy(const unsigned char* seq, int length);
+static inline unsigned char *createReverseCopy(const unsigned char *seq,
+                                               int length);
 
-static inline Word* buildPeq(const int alphabetLength,
-                             const unsigned char* query,
-                             const int queryLength,
-                             const EqualityDefinition& equalityDefinition);
-
+static inline Word *buildPeq(const int alphabetLength,
+                             const unsigned char *query, const int queryLength,
+                             const EqualityDefinition &equalityDefinition);
 
 /**
  * Main edlib method.
  */
-extern "C" EdlibAlignResult edlibAlign(const char* const queryOriginal, const int queryLength,
-                                       const char* const targetOriginal, const int targetLength,
+extern "C" EdlibAlignResult edlibAlign(const char *const queryOriginal,
+                                       const int queryLength,
+                                       const char *const targetOriginal,
+                                       const int targetLength,
                                        const EdlibAlignConfig config) {
-    EdlibAlignResult result;
-    result.status = EDLIB_STATUS_OK;
-    result.editDistance = -1;
-    result.endLocations = result.startLocations = NULL;
-    result.numLocations = 0;
-    result.alignment = NULL;
-    result.alignmentLength = 0;
-    result.alphabetLength = 0;
+  EdlibAlignResult result;
+  result.status = EDLIB_STATUS_OK;
+  result.editDistance = -1;
+  result.endLocations = result.startLocations = NULL;
+  result.numLocations = 0;
+  result.alignment = NULL;
+  result.alignmentLength = 0;
+  result.alphabetLength = 0;
 
-    /*------------ TRANSFORM SEQUENCES AND RECOGNIZE ALPHABET -----------*/
-    unsigned char* query, * target;
-    string alphabet = transformSequences(queryOriginal, queryLength, targetOriginal, targetLength,
-                                         &query, &target);
-    result.alphabetLength = static_cast<int>(alphabet.size());
-    /*-------------------------------------------------------*/
+  /*------------ TRANSFORM SEQUENCES AND RECOGNIZE ALPHABET -----------*/
+  unsigned char *query, *target;
+  string alphabet =
+      transformSequences(queryOriginal, queryLength, targetOriginal,
+                         targetLength, &query, &target);
+  result.alphabetLength = static_cast<int>(alphabet.size());
+  /*-------------------------------------------------------*/
 
-    // Handle special situation when at least one of the sequences has length 0.
-    if (queryLength == 0 || targetLength == 0) {
-        if (config.mode == EDLIB_MODE_NW) {
-            result.editDistance = std::max(queryLength, targetLength);
-            result.endLocations = static_cast<int *>(malloc(sizeof(int) * 1));
-            result.endLocations[0] = targetLength - 1;
-            result.numLocations = 1;
-        } else if (config.mode == EDLIB_MODE_SHW || config.mode == EDLIB_MODE_HW) {
-            result.editDistance = queryLength;
-            result.endLocations = static_cast<int *>(malloc(sizeof(int) * 1));
-            result.endLocations[0] = -1;
-            result.numLocations = 1;
-        } else {
-            result.status = EDLIB_STATUS_ERROR;
-        }
-
-        free(query);
-        free(target);
-        return result;
+  // Handle special situation when at least one of the sequences has length 0.
+  if (queryLength == 0 || targetLength == 0) {
+    if (config.mode == EDLIB_MODE_NW) {
+      result.editDistance = std::max(queryLength, targetLength);
+      result.endLocations = static_cast<int *>(malloc(sizeof(int) * 1));
+      result.endLocations[0] = targetLength - 1;
+      result.numLocations = 1;
+    } else if (config.mode == EDLIB_MODE_SHW || config.mode == EDLIB_MODE_HW) {
+      result.editDistance = queryLength;
+      result.endLocations = static_cast<int *>(malloc(sizeof(int) * 1));
+      result.endLocations[0] = -1;
+      result.numLocations = 1;
+    } else {
+      result.status = EDLIB_STATUS_ERROR;
     }
 
-    /*--------------------- INITIALIZATION ------------------*/
-    int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE); // bmax in Myers
-    int W = maxNumBlocks * WORD_SIZE - queryLength; // number of redundant cells in last level blocks
-    EqualityDefinition equalityDefinition(alphabet, config.additionalEqualities, config.additionalEqualitiesLength);
-    Word* Peq = buildPeq(static_cast<int>(alphabet.size()), query, queryLength, equalityDefinition);
-    /*-------------------------------------------------------*/
-
-    /*------------------ MAIN CALCULATION -------------------*/
-    // TODO: Store alignment data only after k is determined? That could make things faster.
-    int positionNW; // Used only when mode is NW.
-    AlignmentData* alignData = NULL;
-    bool dynamicK = false;
-    int k = config.k;
-    if (k < 0) { // If valid k is not given, auto-adjust k until solution is found.
-        dynamicK = true;
-        k = WORD_SIZE; // Gives better results than smaller k.
-    }
-
-    do {
-        if (config.mode == EDLIB_MODE_HW || config.mode == EDLIB_MODE_SHW) {
-            myersCalcEditDistanceSemiGlobal(Peq, W, maxNumBlocks,
-                                            queryLength, target, targetLength,
-                                            k, config.mode, &(result.editDistance),
-                                            &(result.endLocations), &(result.numLocations));
-        } else {  // mode == EDLIB_MODE_NW
-            myersCalcEditDistanceNW(Peq, W, maxNumBlocks,
-                                    queryLength, target, targetLength,
-                                    k, &(result.editDistance), &positionNW,
-                                    false, &alignData, -1);
-        }
-        k *= 2;
-    } while(dynamicK && result.editDistance == -1);
-
-    if (result.editDistance >= 0) {  // If there is solution.
-        // If NW mode, set end location explicitly.
-        if (config.mode == EDLIB_MODE_NW) {
-            result.endLocations = static_cast<int *>(malloc(sizeof(int) * 1));
-            result.endLocations[0] = targetLength - 1;
-            result.numLocations = 1;
-        }
-
-        // Find starting locations.
-        if (config.task == EDLIB_TASK_LOC || config.task == EDLIB_TASK_PATH) {
-            result.startLocations = static_cast<int *>(malloc(result.numLocations * sizeof(int)));
-            if (config.mode == EDLIB_MODE_HW) {  // If HW, I need to calculate start locations.
-                const unsigned char* rTarget = createReverseCopy(target, targetLength);
-                const unsigned char* rQuery  = createReverseCopy(query, queryLength);
-                // Peq for reversed query.
-                Word* rPeq = buildPeq(static_cast<int>(alphabet.size()), rQuery, queryLength, equalityDefinition);
-                for (int i = 0; i < result.numLocations; i++) {
-                    int endLocation = result.endLocations[i];
-                    if (endLocation == -1) {
-                        // NOTE: Sometimes one of optimal solutions is that query starts before target, like this:
-                        //                       AAGG <- target
-                        //                   CCTT     <- query
-                        //   It will never be only optimal solution and it does not happen often, however it is
-                        //   possible and in that case end location will be -1. What should we do with that?
-                        //   Should we just skip reporting such end location, although it is a solution?
-                        //   If we do report it, what is the start location? -4? -1? Nothing?
-                        // TODO: Figure this out. This has to do in general with how we think about start
-                        //   and end locations.
-                        //   Also, we have alignment later relying on this locations to limit the space of it's
-                        //   search -> how can it do it right if these locations are negative or incorrect?
-                        result.startLocations[i] = 0;  // I put 0 for now, but it does not make much sense.
-                    } else {
-                        int bestScoreSHW, numPositionsSHW;
-                        int* positionsSHW;
-                        myersCalcEditDistanceSemiGlobal(
-                                rPeq, W, maxNumBlocks,
-                                queryLength, rTarget + targetLength - endLocation - 1, endLocation + 1,
-                                result.editDistance, EDLIB_MODE_SHW,
-                                &bestScoreSHW, &positionsSHW, &numPositionsSHW);
-                        // Taking last location as start ensures that alignment will not start with insertions
-                        // if it can start with mismatches instead.
-                        result.startLocations[i] = endLocation - positionsSHW[numPositionsSHW - 1];
-                        free(positionsSHW);
-                    }
-                }
-                delete[] rTarget;
-                delete[] rQuery;
-                delete[] rPeq;
-            } else {  // If mode is SHW or NW
-                for (int i = 0; i < result.numLocations; i++) {
-                    result.startLocations[i] = 0;
-                }
-            }
-        }
-
-        // Find alignment -> all comes down to finding alignment for NW.
-        // Currently we return alignment only for first pair of locations.
-        if (config.task == EDLIB_TASK_PATH) {
-            int alnStartLocation = result.startLocations[0];
-            int alnEndLocation = result.endLocations[0];
-            const unsigned char* alnTarget = target + alnStartLocation;
-            const int alnTargetLength = alnEndLocation - alnStartLocation + 1;
-            const unsigned char* rAlnTarget = createReverseCopy(alnTarget, alnTargetLength);
-            const unsigned char* rQuery  = createReverseCopy(query, queryLength);
-            obtainAlignment(query, rQuery, queryLength,
-                            alnTarget, rAlnTarget, alnTargetLength,
-                            equalityDefinition, static_cast<int>(alphabet.size()), result.editDistance,
-                            &(result.alignment), &(result.alignmentLength));
-            delete[] rAlnTarget;
-            delete[] rQuery;
-        }
-    }
-    /*-------------------------------------------------------*/
-
-    //--- Free memory ---//
-    delete[] Peq;
     free(query);
     free(target);
-    if (alignData) delete alignData;
-    //-------------------//
-
     return result;
+  }
+
+  /*--------------------- INITIALIZATION ------------------*/
+  int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE); // bmax in Myers
+  int W = maxNumBlocks * WORD_SIZE -
+          queryLength; // number of redundant cells in last level blocks
+  EqualityDefinition equalityDefinition(alphabet, config.additionalEqualities,
+                                        config.additionalEqualitiesLength);
+  Word *Peq = buildPeq(static_cast<int>(alphabet.size()), query, queryLength,
+                       equalityDefinition);
+  /*-------------------------------------------------------*/
+
+  /*------------------ MAIN CALCULATION -------------------*/
+  // TODO: Store alignment data only after k is determined? That could make
+  // things faster.
+  int positionNW; // Used only when mode is NW.
+  AlignmentData *alignData = NULL;
+  bool dynamicK = false;
+  int k = config.k;
+  if (k <
+      0) { // If valid k is not given, auto-adjust k until solution is found.
+    dynamicK = true;
+    k = WORD_SIZE; // Gives better results than smaller k.
+  }
+
+  do {
+    if (config.mode == EDLIB_MODE_HW || config.mode == EDLIB_MODE_SHW) {
+      myersCalcEditDistanceSemiGlobal(
+          Peq, W, maxNumBlocks, queryLength, target, targetLength, k,
+          config.mode, &(result.editDistance), &(result.endLocations),
+          &(result.numLocations));
+    } else { // mode == EDLIB_MODE_NW
+      myersCalcEditDistanceNW(Peq, W, maxNumBlocks, queryLength, target,
+                              targetLength, k, &(result.editDistance),
+                              &positionNW, false, &alignData, -1);
+    }
+    k *= 2;
+  } while (dynamicK && result.editDistance == -1);
+
+  if (result.editDistance >= 0) { // If there is solution.
+    // If NW mode, set end location explicitly.
+    if (config.mode == EDLIB_MODE_NW) {
+      result.endLocations = static_cast<int *>(malloc(sizeof(int) * 1));
+      result.endLocations[0] = targetLength - 1;
+      result.numLocations = 1;
+    }
+
+    // Find starting locations.
+    if (config.task == EDLIB_TASK_LOC || config.task == EDLIB_TASK_PATH) {
+      result.startLocations =
+          static_cast<int *>(malloc(result.numLocations * sizeof(int)));
+      if (config.mode ==
+          EDLIB_MODE_HW) { // If HW, I need to calculate start locations.
+        const unsigned char *rTarget = createReverseCopy(target, targetLength);
+        const unsigned char *rQuery = createReverseCopy(query, queryLength);
+        // Peq for reversed query.
+        Word *rPeq = buildPeq(static_cast<int>(alphabet.size()), rQuery,
+                              queryLength, equalityDefinition);
+        for (int i = 0; i < result.numLocations; i++) {
+          int endLocation = result.endLocations[i];
+          if (endLocation == -1) {
+            // NOTE: Sometimes one of optimal solutions is that query starts
+            // before target, like this:
+            //                       AAGG <- target
+            //                   CCTT     <- query
+            //   It will never be only optimal solution and it does not happen
+            //   often, however it is possible and in that case end location
+            //   will be -1. What should we do with that? Should we just skip
+            //   reporting such end location, although it is a solution? If we
+            //   do report it, what is the start location? -4? -1? Nothing?
+            // TODO: Figure this out. This has to do in general with how we
+            // think about start
+            //   and end locations.
+            //   Also, we have alignment later relying on this locations to
+            //   limit the space of it's search -> how can it do it right if
+            //   these locations are negative or incorrect?
+            result.startLocations[i] =
+                0; // I put 0 for now, but it does not make much sense.
+          } else {
+            int bestScoreSHW, numPositionsSHW;
+            int *positionsSHW;
+            myersCalcEditDistanceSemiGlobal(
+                rPeq, W, maxNumBlocks, queryLength,
+                rTarget + targetLength - endLocation - 1, endLocation + 1,
+                result.editDistance, EDLIB_MODE_SHW, &bestScoreSHW,
+                &positionsSHW, &numPositionsSHW);
+            // Taking last location as start ensures that alignment will not
+            // start with insertions if it can start with mismatches instead.
+            result.startLocations[i] =
+                endLocation - positionsSHW[numPositionsSHW - 1];
+            free(positionsSHW);
+          }
+        }
+        delete[] rTarget;
+        delete[] rQuery;
+        delete[] rPeq;
+      } else { // If mode is SHW or NW
+        for (int i = 0; i < result.numLocations; i++) {
+          result.startLocations[i] = 0;
+        }
+      }
+    }
+
+    // Find alignment -> all comes down to finding alignment for NW.
+    // Currently we return alignment only for first pair of locations.
+    if (config.task == EDLIB_TASK_PATH) {
+      int alnStartLocation = result.startLocations[0];
+      int alnEndLocation = result.endLocations[0];
+      const unsigned char *alnTarget = target + alnStartLocation;
+      const int alnTargetLength = alnEndLocation - alnStartLocation + 1;
+      const unsigned char *rAlnTarget =
+          createReverseCopy(alnTarget, alnTargetLength);
+      const unsigned char *rQuery = createReverseCopy(query, queryLength);
+      obtainAlignment(query, rQuery, queryLength, alnTarget, rAlnTarget,
+                      alnTargetLength, equalityDefinition,
+                      static_cast<int>(alphabet.size()), result.editDistance,
+                      &(result.alignment), &(result.alignmentLength));
+      delete[] rAlnTarget;
+      delete[] rQuery;
+    }
+  }
+  /*-------------------------------------------------------*/
+
+  //--- Free memory ---//
+  delete[] Peq;
+  free(query);
+  free(target);
+  if (alignData)
+    delete alignData;
+  //-------------------//
+
+  return result;
 }
 
-extern "C" char* edlibAlignmentToCigar(const unsigned char* const alignment, const int alignmentLength,
+extern "C" char *edlibAlignmentToCigar(const unsigned char *const alignment,
+                                       const int alignmentLength,
                                        const EdlibCigarFormat cigarFormat) {
-    if (cigarFormat != EDLIB_CIGAR_EXTENDED && cigarFormat != EDLIB_CIGAR_STANDARD) {
-        return 0;
-    }
+  if (cigarFormat != EDLIB_CIGAR_EXTENDED &&
+      cigarFormat != EDLIB_CIGAR_STANDARD) {
+    return 0;
+  }
 
-    // Maps move code from alignment to char in cigar.
-    //                        0    1    2    3
-    char moveCodeToChar[] = {'=', 'I', 'D', 'X'};
-    if (cigarFormat == EDLIB_CIGAR_STANDARD) {
-        moveCodeToChar[0] = moveCodeToChar[3] = 'M';
-    }
+  // Maps move code from alignment to char in cigar.
+  //                        0    1    2    3
+  char moveCodeToChar[] = {'=', 'I', 'D', 'X'};
+  if (cigarFormat == EDLIB_CIGAR_STANDARD) {
+    moveCodeToChar[0] = moveCodeToChar[3] = 'M';
+  }
 
-    vector<char>* cigar = new vector<char>();
-    char lastMove = 0;  // Char of last move. 0 if there was no previous move.
-    int numOfSameMoves = 0;
-    for (int i = 0; i <= alignmentLength; i++) {
-        // if new sequence of same moves started
-        if (i == alignmentLength || (moveCodeToChar[alignment[i]] != lastMove && lastMove != 0)) {
-            // Write number of moves to cigar string.
-            int numDigits = 0;
-            for (; numOfSameMoves; numOfSameMoves /= 10) {
-                cigar->push_back('0' + numOfSameMoves % 10);
-                numDigits++;
-            }
-            reverse(cigar->end() - numDigits, cigar->end());
-            // Write code of move to cigar string.
-            cigar->push_back(lastMove);
-            // If not at the end, start new sequence of moves.
-            if (i < alignmentLength) {
-                // Check if alignment has valid values.
-                if (alignment[i] > 3) {
-                    delete cigar;
-                    return 0;
-                }
-                numOfSameMoves = 0;
-            }
+  vector<char> *cigar = new vector<char>();
+  char lastMove = 0; // Char of last move. 0 if there was no previous move.
+  int numOfSameMoves = 0;
+  for (int i = 0; i <= alignmentLength; i++) {
+    // if new sequence of same moves started
+    if (i == alignmentLength ||
+        (moveCodeToChar[alignment[i]] != lastMove && lastMove != 0)) {
+      // Write number of moves to cigar string.
+      int numDigits = 0;
+      for (; numOfSameMoves; numOfSameMoves /= 10) {
+        cigar->push_back('0' + numOfSameMoves % 10);
+        numDigits++;
+      }
+      reverse(cigar->end() - numDigits, cigar->end());
+      // Write code of move to cigar string.
+      cigar->push_back(lastMove);
+      // If not at the end, start new sequence of moves.
+      if (i < alignmentLength) {
+        // Check if alignment has valid values.
+        if (alignment[i] > 3) {
+          delete cigar;
+          return 0;
         }
-        if (i < alignmentLength) {
-            lastMove = moveCodeToChar[alignment[i]];
-            numOfSameMoves++;
-        }
+        numOfSameMoves = 0;
+      }
     }
-    cigar->push_back(0);  // Null character termination.
-    char* cigar_ = static_cast<char *>(malloc(cigar->size() * sizeof(char)));
-    memcpy(cigar_, &(*cigar)[0], cigar->size() * sizeof(char));
-    delete cigar;
+    if (i < alignmentLength) {
+      lastMove = moveCodeToChar[alignment[i]];
+      numOfSameMoves++;
+    }
+  }
+  cigar->push_back(0); // Null character termination.
+  char *cigar_ = static_cast<char *>(malloc(cigar->size() * sizeof(char)));
+  memcpy(cigar_, &(*cigar)[0], cigar->size() * sizeof(char));
+  delete cigar;
 
-    return cigar_;
+  return cigar_;
 }
 
 /**
  * Build Peq table for given query and alphabet.
  * Peq is table of dimensions alphabetLength+1 x maxNumBlocks.
- * Bit i of Peq[s * maxNumBlocks + b] is 1 if i-th symbol from block b of query equals symbol s, otherwise it is 0.
- * NOTICE: free returned array with delete[]!
+ * Bit i of Peq[s * maxNumBlocks + b] is 1 if i-th symbol from block b of query
+ * equals symbol s, otherwise it is 0. NOTICE: free returned array with
+ * delete[]!
  */
-static inline Word* buildPeq(const int alphabetLength,
-                             const unsigned char* const query,
+static inline Word *buildPeq(const int alphabetLength,
+                             const unsigned char *const query,
                              const int queryLength,
-                             const EqualityDefinition& equalityDefinition) {
-    int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
-    // table of dimensions alphabetLength+1 x maxNumBlocks. Last symbol is wildcard.
-    Word* Peq = new Word[(alphabetLength + 1) * maxNumBlocks];
+                             const EqualityDefinition &equalityDefinition) {
+  int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
+  // table of dimensions alphabetLength+1 x maxNumBlocks. Last symbol is
+  // wildcard.
+  Word *Peq = new Word[(alphabetLength + 1) * maxNumBlocks];
 
-    // Build Peq (1 is match, 0 is mismatch). NOTE: last column is wildcard(symbol that matches anything) with just 1s
-    for (int symbol = 0; symbol <= alphabetLength; symbol++) {
-        for (int b = 0; b < maxNumBlocks; b++) {
-            if (symbol < alphabetLength) {
-                Peq[symbol * maxNumBlocks + b] = 0;
-                for (int r = (b+1) * WORD_SIZE - 1; r >= b * WORD_SIZE; r--) {
-                    Peq[symbol * maxNumBlocks + b] <<= 1;
-                    // NOTE: We pretend like query is padded at the end with W wildcard symbols
-                    if (r >= queryLength || equalityDefinition.areEqual(query[r], symbol))
-                        Peq[symbol * maxNumBlocks + b] += 1;
-                }
-            } else { // Last symbol is wildcard, so it is all 1s
-                Peq[symbol * maxNumBlocks + b] = static_cast<Word>(-1);
-            }
+  // Build Peq (1 is match, 0 is mismatch). NOTE: last column is wildcard(symbol
+  // that matches anything) with just 1s
+  for (int symbol = 0; symbol <= alphabetLength; symbol++) {
+    for (int b = 0; b < maxNumBlocks; b++) {
+      if (symbol < alphabetLength) {
+        Peq[symbol * maxNumBlocks + b] = 0;
+        for (int r = (b + 1) * WORD_SIZE - 1; r >= b * WORD_SIZE; r--) {
+          Peq[symbol * maxNumBlocks + b] <<= 1;
+          // NOTE: We pretend like query is padded at the end with W wildcard
+          // symbols
+          if (r >= queryLength || equalityDefinition.areEqual(query[r], symbol))
+            Peq[symbol * maxNumBlocks + b] += 1;
         }
+      } else { // Last symbol is wildcard, so it is all 1s
+        Peq[symbol * maxNumBlocks + b] = static_cast<Word>(-1);
+      }
     }
+  }
 
-    return Peq;
+  return Peq;
 }
-
 
 /**
  * Returns new sequence that is reverse of given sequence.
  * Free returned array with delete[].
  */
-static inline unsigned char* createReverseCopy(const unsigned char* const seq, const int length) {
-    unsigned char* rSeq = new unsigned char[length];
-    for (int i = 0; i < length; i++) {
-        rSeq[i] = seq[length - i - 1];
-    }
-    return rSeq;
+static inline unsigned char *createReverseCopy(const unsigned char *const seq,
+                                               const int length) {
+  unsigned char *rSeq = new unsigned char[length];
+  for (int i = 0; i < length; i++) {
+    rSeq[i] = seq[length - i - 1];
+  }
+  return rSeq;
 }
 
 /**
  * Corresponds to Advance_Block function from Myers.
  * Calculates one word(block), which is part of a column.
- * Highest bit of word (one most to the left) is most bottom cell of block from column.
- * Pv[i] and Mv[i] define vin of cell[i]: vin = cell[i] - cell[i-1].
+ * Highest bit of word (one most to the left) is most bottom cell of block from
+ * column. Pv[i] and Mv[i] define vin of cell[i]: vin = cell[i] - cell[i-1].
  * @param [in] Pv  Bitset, Pv[i] == 1 if vin is +1, otherwise Pv[i] == 0.
  * @param [in] Mv  Bitset, Mv[i] == 1 if vin is -1, otherwise Mv[i] == 0.
  * @param [in] Eq  Bitset, Eq[i] == 1 if match, 0 if mismatch.
  * @param [in] hin  Will be +1, 0 or -1.
- * @param [out] PvOut  Bitset, PvOut[i] == 1 if vout is +1, otherwise PvOut[i] == 0.
- * @param [out] MvOut  Bitset, MvOut[i] == 1 if vout is -1, otherwise MvOut[i] == 0.
+ * @param [out] PvOut  Bitset, PvOut[i] == 1 if vout is +1, otherwise PvOut[i]
+ * == 0.
+ * @param [out] MvOut  Bitset, MvOut[i] == 1 if vout is -1, otherwise MvOut[i]
+ * == 0.
  * @param [out] hout  Will be +1, 0 or -1.
  */
 static inline int calculateBlock(Word Pv, Word Mv, Word Eq, const int hin,
                                  Word &PvOut, Word &MvOut) {
-    // hin can be 1, -1 or 0.
-    // 1  -> 00...01
-    // 0  -> 00...00
-    // -1 -> 11...11 (2-complement)
+  // hin can be 1, -1 or 0.
+  // 1  -> 00...01
+  // 0  -> 00...00
+  // -1 -> 11...11 (2-complement)
 
-    Word hinIsNeg = static_cast<Word>(hin >> 2) & WORD_1; // 00...001 if hin is -1, 00...000 if 0 or 1
+  Word hinIsNeg = static_cast<Word>(hin >> 2) &
+                  WORD_1; // 00...001 if hin is -1, 00...000 if 0 or 1
 
-    Word Xv = Eq | Mv;
-    // This is instruction below written using 'if': if (hin < 0) Eq |= (Word)1;
-    Eq |= hinIsNeg;
-    Word Xh = (((Eq & Pv) + Pv) ^ Pv) | Eq;
+  Word Xv = Eq | Mv;
+  // This is instruction below written using 'if': if (hin < 0) Eq |= (Word)1;
+  Eq |= hinIsNeg;
+  Word Xh = (((Eq & Pv) + Pv) ^ Pv) | Eq;
 
-    Word Ph = Mv | ~(Xh | Pv);
-    Word Mh = Pv & Xh;
+  Word Ph = Mv | ~(Xh | Pv);
+  Word Mh = Pv & Xh;
 
-    int hout = 0;
-    // This is instruction below written using 'if': if (Ph & HIGH_BIT_MASK) hout = 1;
-    hout = (Ph & HIGH_BIT_MASK) >> (WORD_SIZE - 1);
-    // This is instruction below written using 'if': if (Mh & HIGH_BIT_MASK) hout = -1;
-    hout -= (Mh & HIGH_BIT_MASK) >> (WORD_SIZE - 1);
+  int hout = 0;
+  // This is instruction below written using 'if': if (Ph & HIGH_BIT_MASK) hout
+  // = 1;
+  hout = (Ph & HIGH_BIT_MASK) >> (WORD_SIZE - 1);
+  // This is instruction below written using 'if': if (Mh & HIGH_BIT_MASK) hout
+  // = -1;
+  hout -= (Mh & HIGH_BIT_MASK) >> (WORD_SIZE - 1);
 
-    Ph <<= 1;
-    Mh <<= 1;
+  Ph <<= 1;
+  Mh <<= 1;
 
-    // This is instruction below written using 'if': if (hin < 0) Mh |= (Word)1;
-    Mh |= hinIsNeg;
-    // This is instruction below written using 'if': if (hin > 0) Ph |= (Word)1;
-    Ph |= static_cast<Word>((hin + 1) >> 1);
+  // This is instruction below written using 'if': if (hin < 0) Mh |= (Word)1;
+  Mh |= hinIsNeg;
+  // This is instruction below written using 'if': if (hin > 0) Ph |= (Word)1;
+  Ph |= static_cast<Word>((hin + 1) >> 1);
 
-    PvOut = Mh | ~(Xv | Ph);
-    MvOut = Ph & Xv;
+  PvOut = Mh | ~(Xv | Ph);
+  MvOut = Ph & Xv;
 
-    return hout;
+  return hout;
 }
 
 /**
@@ -448,68 +484,73 @@ static inline int calculateBlock(Word Pv, Word Mv, Word Eq, const int hin,
  * Note: x and y must be non-negative and x + y must not overflow.
  */
 static inline int ceilDiv(const int x, const int y) {
-    return x % y ? x / y + 1 : x / y;
+  return x % y ? x / y + 1 : x / y;
 }
 
-static inline int min(const int x, const int y) {
-    return x < y ? x : y;
-}
+static inline int min(const int x, const int y) { return x < y ? x : y; }
 
-static inline int max(const int x, const int y) {
-    return x > y ? x : y;
-}
-
+static inline int max(const int x, const int y) { return x > y ? x : y; }
 
 /**
  * @param [in] block
  * @return Values of cells in block, starting with bottom cell in block.
  */
 static inline vector<int> getBlockCellValues(const Block block) {
-    vector<int> scores(WORD_SIZE);
-    int score = block.score;
-    Word mask = HIGH_BIT_MASK;
-    for (int i = 0; i < WORD_SIZE - 1; i++) {
-        scores[i] = score;
-        if (block.P & mask) score--;
-        if (block.M & mask) score++;
-        mask >>= 1;
-    }
-    scores[WORD_SIZE - 1] = score;
-    return scores;
+  vector<int> scores(WORD_SIZE);
+  int score = block.score;
+  Word mask = HIGH_BIT_MASK;
+  for (int i = 0; i < WORD_SIZE - 1; i++) {
+    scores[i] = score;
+    if (block.P & mask)
+      score--;
+    if (block.M & mask)
+      score++;
+    mask >>= 1;
+  }
+  scores[WORD_SIZE - 1] = score;
+  return scores;
 }
 
 /**
- * Writes values of cells in block into given array, starting with first/top cell.
+ * Writes values of cells in block into given array, starting with first/top
+ * cell.
  * @param [in] block
- * @param [out] dest  Array into which cell values are written. Must have size of at least WORD_SIZE.
+ * @param [out] dest  Array into which cell values are written. Must have size
+ * of at least WORD_SIZE.
  */
-static inline void readBlock(const Block block, int* const dest) {
-    int score = block.score;
-    Word mask = HIGH_BIT_MASK;
-    for (int i = 0; i < WORD_SIZE - 1; i++) {
-        dest[WORD_SIZE - 1 - i] = score;
-        if (block.P & mask) score--;
-        if (block.M & mask) score++;
-        mask >>= 1;
-    }
-    dest[0] = score;
+static inline void readBlock(const Block block, int *const dest) {
+  int score = block.score;
+  Word mask = HIGH_BIT_MASK;
+  for (int i = 0; i < WORD_SIZE - 1; i++) {
+    dest[WORD_SIZE - 1 - i] = score;
+    if (block.P & mask)
+      score--;
+    if (block.M & mask)
+      score++;
+    mask >>= 1;
+  }
+  dest[0] = score;
 }
 
 /**
- * Writes values of cells in block into given array, starting with last/bottom cell.
+ * Writes values of cells in block into given array, starting with last/bottom
+ * cell.
  * @param [in] block
- * @param [out] dest  Array into which cell values are written. Must have size of at least WORD_SIZE.
+ * @param [out] dest  Array into which cell values are written. Must have size
+ * of at least WORD_SIZE.
  */
-static inline void readBlockReverse(const Block block, int* const dest) {
-    int score = block.score;
-    Word mask = HIGH_BIT_MASK;
-    for (int i = 0; i < WORD_SIZE - 1; i++) {
-        dest[i] = score;
-        if (block.P & mask) score--;
-        if (block.M & mask) score++;
-        mask >>= 1;
-    }
-    dest[WORD_SIZE - 1] = score;
+static inline void readBlockReverse(const Block block, int *const dest) {
+  int score = block.score;
+  Word mask = HIGH_BIT_MASK;
+  for (int i = 0; i < WORD_SIZE - 1; i++) {
+    dest[i] = score;
+    if (block.P & mask)
+      score--;
+    if (block.M & mask)
+      score++;
+    mask >>= 1;
+  }
+  dest[WORD_SIZE - 1] = score;
 }
 
 /**
@@ -518,636 +559,705 @@ static inline void readBlockReverse(const Block block, int* const dest) {
  * @return True if all cells in block have value larger than k, otherwise false.
  */
 static inline bool allBlockCellsLarger(const Block block, const int k) {
-    vector<int> scores = getBlockCellValues(block);
-    for (int i = 0; i < WORD_SIZE; i++) {
-        if (scores[i] <= k) return false;
-    }
-    return true;
+  vector<int> scores = getBlockCellValues(block);
+  for (int i = 0; i < WORD_SIZE; i++) {
+    if (scores[i] <= k)
+      return false;
+  }
+  return true;
 }
 
-
 /**
- * Uses Myers' bit-vector algorithm to find edit distance for one of semi-global alignment methods.
+ * Uses Myers' bit-vector algorithm to find edit distance for one of semi-global
+ alignment methods.
  * @param [in] Peq  Query profile.
  * @param [in] W  Size of padding in last block.
- *                TODO: Calculate this directly from query, instead of passing it.
+ *                TODO: Calculate this directly from query, instead of passing
+ it.
  * @param [in] maxNumBlocks  Number of blocks needed to cover the whole query.
- *                           TODO: Calculate this directly from query, instead of passing it.
+ *                           TODO: Calculate this directly from query, instead
+ of passing it.
  * @param [in] queryLength
  * @param [in] target
  * @param [in] targetLength
  * @param [in] k
  * @param [in] mode  EDLIB_MODE_HW or EDLIB_MODE_SHW
  * @param [out] bestScore_  Edit distance.
- * @param [out] positions_  Array of 0-indexed positions in target at which best score was found.
-                            Make sure to free this array with free().
+ * @param [out] positions_  Array of 0-indexed positions in target at which best
+ score was found. Make sure to free this array with free().
  * @param [out] numPositions_  Number of positions in the positions_ array.
  * @return Status.
  */
 static int myersCalcEditDistanceSemiGlobal(
-        const Word* const Peq, const int W, const int maxNumBlocks,
-        const int queryLength,
-        const unsigned char* const target, const int targetLength,
-        int k, const EdlibAlignMode mode,
-        int* const bestScore_, int** const positions_, int* const numPositions_) {
-    *positions_ = NULL;
-    *numPositions_ = 0;
+    const Word *const Peq, const int W, const int maxNumBlocks,
+    const int queryLength, const unsigned char *const target,
+    const int targetLength, int k, const EdlibAlignMode mode,
+    int *const bestScore_, int **const positions_, int *const numPositions_) {
+  *positions_ = NULL;
+  *numPositions_ = 0;
 
-    // firstBlock is 0-based index of first block in Ukkonen band.
-    // lastBlock is 0-based index of last block in Ukkonen band.
-    int firstBlock = 0;
-    int lastBlock = min(ceilDiv(k + 1, WORD_SIZE), maxNumBlocks) - 1; // y in Myers
-    Block *bl; // Current block
+  // firstBlock is 0-based index of first block in Ukkonen band.
+  // lastBlock is 0-based index of last block in Ukkonen band.
+  int firstBlock = 0;
+  int lastBlock =
+      min(ceilDiv(k + 1, WORD_SIZE), maxNumBlocks) - 1; // y in Myers
+  Block *bl;                                            // Current block
 
-    Block* blocks = new Block[maxNumBlocks];
+  Block *blocks = new Block[maxNumBlocks];
 
-    // For HW, solution will never be larger then queryLength.
-    if (mode == EDLIB_MODE_HW) {
-        k = min(queryLength, k);
+  // For HW, solution will never be larger then queryLength.
+  if (mode == EDLIB_MODE_HW) {
+    k = min(queryLength, k);
+  }
+
+  // Each STRONG_REDUCE_NUM column is reduced in more expensive way.
+  // This gives speed up of about 2 times for small k.
+  const int STRONG_REDUCE_NUM = 2048;
+
+  // Initialize P, M and score
+  bl = blocks;
+  for (int b = 0; b <= lastBlock; b++) {
+    bl->score = (b + 1) * WORD_SIZE;
+    bl->P = static_cast<Word>(-1); // All 1s
+    bl->M = static_cast<Word>(0);
+    bl++;
+  }
+
+  int bestScore = -1;
+  vector<int> positions; // TODO: Maybe put this on heap?
+  const int startHout = mode == EDLIB_MODE_HW
+                            ? 0
+                            : 1; // If 0 then gap before query is not penalized;
+  const unsigned char *targetChar = target;
+  for (int c = 0; c < targetLength; c++) { // for each column
+    const Word *Peq_c = Peq + (*targetChar) * maxNumBlocks;
+
+    //----------------------- Calculate column -------------------------//
+    int hout = startHout;
+    bl = blocks + firstBlock;
+    Peq_c += firstBlock;
+    for (int b = firstBlock; b <= lastBlock; b++) {
+      hout = calculateBlock(bl->P, bl->M, *Peq_c, hout, bl->P, bl->M);
+      bl->score += hout;
+      bl++;
+      Peq_c++;
+    }
+    bl--;
+    Peq_c--;
+    //------------------------------------------------------------------//
+
+    //---------- Adjust number of blocks according to Ukkonen ----------//
+    if ((lastBlock < maxNumBlocks - 1) &&
+        (bl->score - hout <= k) // bl is pointing to last block
+        && ((*(Peq_c + 1) & WORD_1) ||
+            hout < 0)) { // Peq_c is pointing to last block
+      // If score of left block is not too big, calculate one more block
+      lastBlock++;
+      bl++;
+      Peq_c++;
+      bl->P = static_cast<Word>(-1); // All 1s
+      bl->M = static_cast<Word>(0);
+      bl->score = (bl - 1)->score - hout + WORD_SIZE +
+                  calculateBlock(bl->P, bl->M, *Peq_c, hout, bl->P, bl->M);
+    } else {
+      while (lastBlock >= firstBlock && bl->score >= k + WORD_SIZE) {
+        lastBlock--;
+        bl--;
+        Peq_c--;
+      }
     }
 
-    // Each STRONG_REDUCE_NUM column is reduced in more expensive way.
-    // This gives speed up of about 2 times for small k.
-    const int STRONG_REDUCE_NUM = 2048;
-
-    // Initialize P, M and score
-    bl = blocks;
-    for (int b = 0; b <= lastBlock; b++) {
-        bl->score = (b + 1) * WORD_SIZE;
-        bl->P = static_cast<Word>(-1); // All 1s
-        bl->M = static_cast<Word>(0);
-        bl++;
+    // Every some columns, do some expensive but also more efficient block
+    // reducing. This is important!
+    //
+    // Reduce the band by decreasing last block if possible.
+    if (c % STRONG_REDUCE_NUM == 0) {
+      while (lastBlock >= 0 && lastBlock >= firstBlock &&
+             allBlockCellsLarger(*bl, k)) {
+        lastBlock--;
+        bl--;
+        Peq_c--;
+      }
+    }
+    // For HW, even if all cells are > k, there still may be solution in next
+    // column because starting conditions at upper boundary are 0.
+    // That means that first block is always candidate for solution,
+    // and we can never end calculation before last column.
+    if (mode == EDLIB_MODE_HW && lastBlock == -1) {
+      lastBlock++;
+      bl++;
+      Peq_c++;
     }
 
-    int bestScore = -1;
-    vector<int> positions; // TODO: Maybe put this on heap?
-    const int startHout = mode == EDLIB_MODE_HW ? 0 : 1; // If 0 then gap before query is not penalized;
-    const unsigned char* targetChar = target;
-    for (int c = 0; c < targetLength; c++) { // for each column
-        const Word* Peq_c = Peq + (*targetChar) * maxNumBlocks;
-
-        //----------------------- Calculate column -------------------------//
-        int hout = startHout;
-        bl = blocks + firstBlock;
-        Peq_c += firstBlock;
-        for (int b = firstBlock; b <= lastBlock; b++) {
-            hout = calculateBlock(bl->P, bl->M, *Peq_c, hout, bl->P, bl->M);
-            bl->score += hout;
-            bl++; Peq_c++;
+    // Reduce band by increasing first block if possible. Not applicable to HW.
+    if (mode != EDLIB_MODE_HW) {
+      while (firstBlock <= lastBlock &&
+             blocks[firstBlock].score >= k + WORD_SIZE) {
+        firstBlock++;
+      }
+      if (c % STRONG_REDUCE_NUM == 0) { // Do strong reduction every some blocks
+        while (firstBlock <= lastBlock &&
+               allBlockCellsLarger(blocks[firstBlock], k)) {
+          firstBlock++;
         }
-        bl--; Peq_c--;
-        //------------------------------------------------------------------//
-
-        //---------- Adjust number of blocks according to Ukkonen ----------//
-        if ((lastBlock < maxNumBlocks - 1) && (bl->score - hout <= k) // bl is pointing to last block
-            && ((*(Peq_c + 1) & WORD_1) || hout < 0)) { // Peq_c is pointing to last block
-            // If score of left block is not too big, calculate one more block
-            lastBlock++; bl++; Peq_c++;
-            bl->P = static_cast<Word>(-1); // All 1s
-            bl->M = static_cast<Word>(0);
-            bl->score = (bl - 1)->score - hout + WORD_SIZE + calculateBlock(bl->P, bl->M, *Peq_c, hout, bl->P, bl->M);
-        } else {
-            while (lastBlock >= firstBlock && bl->score >= k + WORD_SIZE) {
-                lastBlock--; bl--; Peq_c--;
-            }
-        }
-
-        // Every some columns, do some expensive but also more efficient block reducing.
-        // This is important!
-        //
-        // Reduce the band by decreasing last block if possible.
-        if (c % STRONG_REDUCE_NUM == 0) {
-            while (lastBlock >= 0 && lastBlock >= firstBlock && allBlockCellsLarger(*bl, k)) {
-                lastBlock--; bl--; Peq_c--;
-            }
-        }
-        // For HW, even if all cells are > k, there still may be solution in next
-        // column because starting conditions at upper boundary are 0.
-        // That means that first block is always candidate for solution,
-        // and we can never end calculation before last column.
-        if (mode == EDLIB_MODE_HW && lastBlock == -1) {
-            lastBlock++; bl++; Peq_c++;
-        }
-
-        // Reduce band by increasing first block if possible. Not applicable to HW.
-        if (mode != EDLIB_MODE_HW) {
-            while (firstBlock <= lastBlock && blocks[firstBlock].score >= k + WORD_SIZE) {
-                firstBlock++;
-            }
-            if (c % STRONG_REDUCE_NUM == 0) { // Do strong reduction every some blocks
-                while (firstBlock <= lastBlock && allBlockCellsLarger(blocks[firstBlock], k)) {
-                    firstBlock++;
-                }
-            }
-        }
-
-        // If band stops to exist finish
-        if (lastBlock < firstBlock) {
-            *bestScore_ = bestScore;
-            if (bestScore != -1) {
-                *positions_ = static_cast<int *>(malloc(sizeof(int) * static_cast<int>(positions.size())));
-                *numPositions_ = static_cast<int>(positions.size());
-                copy(positions.begin(), positions.end(), *positions_);
-            }
-            delete[] blocks;
-            return EDLIB_STATUS_OK;
-        }
-        //------------------------------------------------------------------//
-
-        //------------------------- Update best score ----------------------//
-        if (lastBlock == maxNumBlocks - 1) {
-            int colScore = bl->score;
-            if (colScore <= k) { // Scores > k dont have correct values (so we cannot use them), but are certainly > k.
-                // NOTE: Score that I find in column c is actually score from column c-W
-                if (bestScore == -1 || colScore <= bestScore) {
-                    if (colScore != bestScore) {
-                        positions.clear();
-                        bestScore = colScore;
-                        // Change k so we will look only for equal or better
-                        // scores then the best found so far.
-                        k = bestScore;
-                    }
-                    positions.push_back(c - W);
-                }
-            }
-        }
-        //------------------------------------------------------------------//
-
-        targetChar++;
+      }
     }
 
-
-    // Obtain results for last W columns from last column.
-    if (lastBlock == maxNumBlocks - 1) {
-        vector<int> blockScores = getBlockCellValues(*bl);
-        for (int i = 0; i < W; i++) {
-            int colScore = blockScores[i + 1];
-            if (colScore <= k && (bestScore == -1 || colScore <= bestScore)) {
-                if (colScore != bestScore) {
-                    positions.clear();
-                    k = bestScore = colScore;
-                }
-                positions.push_back(targetLength - W + i);
-            }
-        }
-    }
-
-    *bestScore_ = bestScore;
-    if (bestScore != -1) {
-        *positions_ = static_cast<int *>(malloc(sizeof(int) * static_cast<int>(positions.size())));
+    // If band stops to exist finish
+    if (lastBlock < firstBlock) {
+      *bestScore_ = bestScore;
+      if (bestScore != -1) {
+        *positions_ = static_cast<int *>(
+            malloc(sizeof(int) * static_cast<int>(positions.size())));
         *numPositions_ = static_cast<int>(positions.size());
         copy(positions.begin(), positions.end(), *positions_);
+      }
+      delete[] blocks;
+      return EDLIB_STATUS_OK;
     }
+    //------------------------------------------------------------------//
 
-    delete[] blocks;
-    return EDLIB_STATUS_OK;
+    //------------------------- Update best score ----------------------//
+    if (lastBlock == maxNumBlocks - 1) {
+      int colScore = bl->score;
+      if (colScore <= k) { // Scores > k dont have correct values (so we cannot
+                           // use them), but are certainly > k.
+        // NOTE: Score that I find in column c is actually score from column c-W
+        if (bestScore == -1 || colScore <= bestScore) {
+          if (colScore != bestScore) {
+            positions.clear();
+            bestScore = colScore;
+            // Change k so we will look only for equal or better
+            // scores then the best found so far.
+            k = bestScore;
+          }
+          positions.push_back(c - W);
+        }
+      }
+    }
+    //------------------------------------------------------------------//
+
+    targetChar++;
+  }
+
+  // Obtain results for last W columns from last column.
+  if (lastBlock == maxNumBlocks - 1) {
+    vector<int> blockScores = getBlockCellValues(*bl);
+    for (int i = 0; i < W; i++) {
+      int colScore = blockScores[i + 1];
+      if (colScore <= k && (bestScore == -1 || colScore <= bestScore)) {
+        if (colScore != bestScore) {
+          positions.clear();
+          k = bestScore = colScore;
+        }
+        positions.push_back(targetLength - W + i);
+      }
+    }
+  }
+
+  *bestScore_ = bestScore;
+  if (bestScore != -1) {
+    *positions_ = static_cast<int *>(
+        malloc(sizeof(int) * static_cast<int>(positions.size())));
+    *numPositions_ = static_cast<int>(positions.size());
+    copy(positions.begin(), positions.end(), *positions_);
+  }
+
+  delete[] blocks;
+  return EDLIB_STATUS_OK;
 }
 
-
 /**
- * Uses Myers' bit-vector algorithm to find edit distance for global(NW) alignment method.
+ * Uses Myers' bit-vector algorithm to find edit distance for global(NW)
+ * alignment method.
  * @param [in] Peq  Query profile.
  * @param [in] W  Size of padding in last block.
- *                TODO: Calculate this directly from query, instead of passing it.
+ *                TODO: Calculate this directly from query, instead of passing
+ * it.
  * @param [in] maxNumBlocks  Number of blocks needed to cover the whole query.
- *                           TODO: Calculate this directly from query, instead of passing it.
+ *                           TODO: Calculate this directly from query, instead
+ * of passing it.
  * @param [in] queryLength
  * @param [in] target
  * @param [in] targetLength
  * @param [in] k
  * @param [out] bestScore_  Edit distance.
- * @param [out] position_  0-indexed position in target at which best score was found.
- * @param [in] findAlignment  If true, whole matrix is remembered and alignment data is returned.
- *                            Quadratic amount of memory is consumed.
- * @param [out] alignData  Data needed for alignment traceback (for reconstruction of alignment).
- *                         Set only if findAlignment is set to true, otherwise it is NULL.
- *                         Make sure to free this array using delete[].
- * @param [out] targetStopPosition  If set to -1, whole calculation is performed normally, as expected.
- *         If set to p, calculation is performed up to position p in target (inclusive)
- *         and column p is returned as the only column in alignData.
+ * @param [out] position_  0-indexed position in target at which best score was
+ * found.
+ * @param [in] findAlignment  If true, whole matrix is remembered and alignment
+ * data is returned. Quadratic amount of memory is consumed.
+ * @param [out] alignData  Data needed for alignment traceback (for
+ * reconstruction of alignment). Set only if findAlignment is set to true,
+ * otherwise it is NULL. Make sure to free this array using delete[].
+ * @param [out] targetStopPosition  If set to -1, whole calculation is performed
+ * normally, as expected. If set to p, calculation is performed up to position p
+ * in target (inclusive) and column p is returned as the only column in
+ * alignData.
  * @return Status.
  */
-static int myersCalcEditDistanceNW(const Word* const Peq, const int W, const int maxNumBlocks,
-                                   const int queryLength,
-                                   const unsigned char* const target, const int targetLength,
-                                   int k, int* const bestScore_,
-                                   int* const position_, const bool findAlignment,
-                                   AlignmentData** const alignData, const int targetStopPosition) {
-    if (targetStopPosition > -1 && findAlignment) {
-        // They can not be both set at the same time!
-        return EDLIB_STATUS_ERROR;
-    }
+static int myersCalcEditDistanceNW(
+    const Word *const Peq, const int W, const int maxNumBlocks,
+    const int queryLength, const unsigned char *const target,
+    const int targetLength, int k, int *const bestScore_, int *const position_,
+    const bool findAlignment, AlignmentData **const alignData,
+    const int targetStopPosition) {
+  if (targetStopPosition > -1 && findAlignment) {
+    // They can not be both set at the same time!
+    return EDLIB_STATUS_ERROR;
+  }
 
-    // Each STRONG_REDUCE_NUM column is reduced in more expensive way.
-    const int STRONG_REDUCE_NUM = 2048; // TODO: Choose this number dinamically (based on query and target lengths?), so it does not affect speed of computation
+  // Each STRONG_REDUCE_NUM column is reduced in more expensive way.
+  const int STRONG_REDUCE_NUM =
+      2048; // TODO: Choose this number dinamically (based on query and target
+            // lengths?), so it does not affect speed of computation
 
-    if (k < abs(targetLength - queryLength)) {
-        *bestScore_ = *position_ = -1;
-        return EDLIB_STATUS_OK;
-    }
-
-    k = min(k, max(queryLength, targetLength));  // Upper bound for k
-
-    // firstBlock is 0-based index of first block in Ukkonen band.
-    // lastBlock is 0-based index of last block in Ukkonen band.
-    int firstBlock = 0;
-    // This is optimal now, by my formula.
-    int lastBlock = min(maxNumBlocks, ceilDiv(min(k, (k + queryLength - targetLength) / 2) + 1, WORD_SIZE)) - 1;
-    Block* bl; // Current block
-
-    Block* blocks = new Block[maxNumBlocks];
-
-    // Initialize P, M and score
-    bl = blocks;
-    for (int b = 0; b <= lastBlock; b++) {
-        bl->score = (b + 1) * WORD_SIZE;
-        bl->P = static_cast<Word>(-1); // All 1s
-        bl->M = static_cast<Word>(0);
-        bl++;
-    }
-
-    // If we want to find alignment, we have to store needed data.
-    if (findAlignment)
-        *alignData = new AlignmentData(maxNumBlocks, targetLength);
-    else if (targetStopPosition > -1)
-        *alignData = new AlignmentData(maxNumBlocks, 1);
-    else
-        *alignData = NULL;
-
-    const unsigned char* targetChar = target;
-    for (int c = 0; c < targetLength; c++) { // for each column
-        const Word* Peq_c = Peq + *targetChar * maxNumBlocks;
-
-        //----------------------- Calculate column -------------------------//
-        int hout = 1;
-        bl = blocks + firstBlock;
-        for (int b = firstBlock; b <= lastBlock; b++) {
-            hout = calculateBlock(bl->P, bl->M, Peq_c[b], hout, bl->P, bl->M);
-            bl->score += hout;
-            bl++;
-        }
-        bl--;
-        //------------------------------------------------------------------//
-        // bl now points to last block
-
-        // Update k. I do it only on end of column because it would slow calculation too much otherwise.
-        // NOTICE: I add W when in last block because it is actually result from W cells to the left and W cells up.
-        k = min(k, bl->score
-                + max(targetLength - c - 1, queryLength - ((1 + lastBlock) * WORD_SIZE - 1) - 1)
-                + (lastBlock == maxNumBlocks - 1 ? W : 0));
-
-        //---------- Adjust number of blocks according to Ukkonen ----------//
-        //--- Adjust last block ---//
-        // If block is not beneath band, calculate next block. Only next because others are certainly beneath band.
-        if (lastBlock + 1 < maxNumBlocks
-            && !(//score[lastBlock] >= k + WORD_SIZE ||  // NOTICE: this condition could be satisfied if above block also!
-                 ((lastBlock + 1) * WORD_SIZE - 1
-                  > k - bl->score + 2 * WORD_SIZE - 2 - targetLength + c + queryLength))) {
-            lastBlock++; bl++;
-            bl->P = static_cast<Word>(-1); // All 1s
-            bl->M = static_cast<Word>(0);
-            int newHout = calculateBlock(bl->P, bl->M, Peq_c[lastBlock], hout, bl->P, bl->M);
-            bl->score = (bl - 1)->score - hout + WORD_SIZE + newHout;
-            hout = newHout;
-        }
-
-        // While block is out of band, move one block up.
-        // NOTE: Condition used here is more loose than the one from the article, since I simplified the max() part of it.
-        // I could consider adding that max part, for optimal performance.
-        while (lastBlock >= firstBlock
-               && (bl->score >= k + WORD_SIZE
-                   || ((lastBlock + 1) * WORD_SIZE - 1 >
-                       // TODO: Does not work if do not put +1! Why???
-                       k - bl->score + 2 * WORD_SIZE - 2 - targetLength + c + queryLength + 1))) {
-            lastBlock--; bl--;
-        }
-        //-------------------------//
-
-        //--- Adjust first block ---//
-        // While outside of band, advance block
-        while (firstBlock <= lastBlock
-               && (blocks[firstBlock].score >= k + WORD_SIZE
-                   || ((firstBlock + 1) * WORD_SIZE - 1 <
-                       blocks[firstBlock].score - k - targetLength + queryLength + c))) {
-            firstBlock++;
-        }
-        //--------------------------/
-
-
-        // TODO: consider if this part is useful, it does not seem to help much
-        if (c % STRONG_REDUCE_NUM == 0) { // Every some columns do more expensive but more efficient reduction
-            while (lastBlock >= firstBlock) {
-                // If all cells outside of band, remove block
-                vector<int> scores = getBlockCellValues(*bl);
-                int numCells = lastBlock == maxNumBlocks - 1 ? WORD_SIZE - W : WORD_SIZE;
-                int r = lastBlock * WORD_SIZE + numCells - 1;
-                bool reduce = true;
-                for (int i = WORD_SIZE - numCells; i < WORD_SIZE; i++) {
-                    // TODO: Does not work if do not put +1! Why???
-                    if (scores[i] <= k && r <= k - scores[i] - targetLength + c + queryLength + 1) {
-                        reduce = false;
-                        break;
-                    }
-                    r--;
-                }
-                if (!reduce) break;
-                lastBlock--; bl--;
-            }
-
-            while (firstBlock <= lastBlock) {
-                // If all cells outside of band, remove block
-                vector<int> scores = getBlockCellValues(blocks[firstBlock]);
-                int numCells = firstBlock == maxNumBlocks - 1 ? WORD_SIZE - W : WORD_SIZE;
-                int r = firstBlock * WORD_SIZE + numCells - 1;
-                bool reduce = true;
-                for (int i = WORD_SIZE - numCells; i < WORD_SIZE; i++) {
-                    if (scores[i] <= k && r >= scores[i] - k - targetLength + c + queryLength) {
-                        reduce = false;
-                        break;
-                    }
-                    r--;
-                }
-                if (!reduce) break;
-                firstBlock++;
-            }
-        }
-
-
-        // If band stops to exist finish
-        if (lastBlock < firstBlock) {
-            *bestScore_ = *position_ = -1;
-            delete[] blocks;
-            return EDLIB_STATUS_OK;
-        }
-        //------------------------------------------------------------------//
-
-
-        //---- Save column so it can be used for reconstruction ----//
-        if (findAlignment && c < targetLength) {
-            bl = blocks + firstBlock;
-            for (int b = firstBlock; b <= lastBlock; b++) {
-                (*alignData)->Ps[maxNumBlocks * c + b] = bl->P;
-                (*alignData)->Ms[maxNumBlocks * c + b] = bl->M;
-                (*alignData)->scores[maxNumBlocks * c + b] = bl->score;
-                (*alignData)->firstBlocks[c] = firstBlock;
-                (*alignData)->lastBlocks[c] = lastBlock;
-                bl++;
-            }
-        }
-        //----------------------------------------------------------//
-        //---- If this is stop column, save it and finish ----//
-        if (c == targetStopPosition) {
-            for (int b = firstBlock; b <= lastBlock; b++) {
-                (*alignData)->Ps[b] = (blocks + b)->P;
-                (*alignData)->Ms[b] = (blocks + b)->M;
-                (*alignData)->scores[b] = (blocks + b)->score;
-                (*alignData)->firstBlocks[0] = firstBlock;
-                (*alignData)->lastBlocks[0] = lastBlock;
-            }
-            *bestScore_ = -1;
-            *position_ = targetStopPosition;
-            delete[] blocks;
-            return EDLIB_STATUS_OK;
-        }
-        //----------------------------------------------------//
-
-        targetChar++;
-    }
-
-    if (lastBlock == maxNumBlocks - 1) { // If last block of last column was calculated
-        // Obtain best score from block -> it is complicated because query is padded with W cells
-        int bestScore = getBlockCellValues(blocks[lastBlock])[W];
-        if (bestScore <= k) {
-            *bestScore_ = bestScore;
-            *position_ = targetLength - 1;
-            delete[] blocks;
-            return EDLIB_STATUS_OK;
-        }
-    }
-
+  if (k < abs(targetLength - queryLength)) {
     *bestScore_ = *position_ = -1;
-    delete[] blocks;
     return EDLIB_STATUS_OK;
+  }
+
+  k = min(k, max(queryLength, targetLength)); // Upper bound for k
+
+  // firstBlock is 0-based index of first block in Ukkonen band.
+  // lastBlock is 0-based index of last block in Ukkonen band.
+  int firstBlock = 0;
+  // This is optimal now, by my formula.
+  int lastBlock = min(maxNumBlocks,
+                      ceilDiv(min(k, (k + queryLength - targetLength) / 2) + 1,
+                              WORD_SIZE)) -
+                  1;
+  Block *bl; // Current block
+
+  Block *blocks = new Block[maxNumBlocks];
+
+  // Initialize P, M and score
+  bl = blocks;
+  for (int b = 0; b <= lastBlock; b++) {
+    bl->score = (b + 1) * WORD_SIZE;
+    bl->P = static_cast<Word>(-1); // All 1s
+    bl->M = static_cast<Word>(0);
+    bl++;
+  }
+
+  // If we want to find alignment, we have to store needed data.
+  if (findAlignment)
+    *alignData = new AlignmentData(maxNumBlocks, targetLength);
+  else if (targetStopPosition > -1)
+    *alignData = new AlignmentData(maxNumBlocks, 1);
+  else
+    *alignData = NULL;
+
+  const unsigned char *targetChar = target;
+  for (int c = 0; c < targetLength; c++) { // for each column
+    const Word *Peq_c = Peq + *targetChar * maxNumBlocks;
+
+    //----------------------- Calculate column -------------------------//
+    int hout = 1;
+    bl = blocks + firstBlock;
+    for (int b = firstBlock; b <= lastBlock; b++) {
+      hout = calculateBlock(bl->P, bl->M, Peq_c[b], hout, bl->P, bl->M);
+      bl->score += hout;
+      bl++;
+    }
+    bl--;
+    //------------------------------------------------------------------//
+    // bl now points to last block
+
+    // Update k. I do it only on end of column because it would slow calculation
+    // too much otherwise. NOTICE: I add W when in last block because it is
+    // actually result from W cells to the left and W cells up.
+    k = min(k, bl->score +
+                   max(targetLength - c - 1,
+                       queryLength - ((1 + lastBlock) * WORD_SIZE - 1) - 1) +
+                   (lastBlock == maxNumBlocks - 1 ? W : 0));
+
+    //---------- Adjust number of blocks according to Ukkonen ----------//
+    //--- Adjust last block ---//
+    // If block is not beneath band, calculate next block. Only next because
+    // others are certainly beneath band.
+    if (lastBlock + 1 < maxNumBlocks &&
+        !( // score[lastBlock] >= k + WORD_SIZE ||  // NOTICE: this condition
+           // could be satisfied if above block also!
+            ((lastBlock + 1) * WORD_SIZE - 1 > k - bl->score + 2 * WORD_SIZE -
+                                                   2 - targetLength + c +
+                                                   queryLength))) {
+      lastBlock++;
+      bl++;
+      bl->P = static_cast<Word>(-1); // All 1s
+      bl->M = static_cast<Word>(0);
+      int newHout =
+          calculateBlock(bl->P, bl->M, Peq_c[lastBlock], hout, bl->P, bl->M);
+      bl->score = (bl - 1)->score - hout + WORD_SIZE + newHout;
+      hout = newHout;
+    }
+
+    // While block is out of band, move one block up.
+    // NOTE: Condition used here is more loose than the one from the article,
+    // since I simplified the max() part of it. I could consider adding that max
+    // part, for optimal performance.
+    while (lastBlock >= firstBlock &&
+           (bl->score >= k + WORD_SIZE ||
+            ((lastBlock + 1) * WORD_SIZE - 1 >
+             // TODO: Does not work if do not put +1! Why???
+             k - bl->score + 2 * WORD_SIZE - 2 - targetLength + c +
+                 queryLength + 1))) {
+      lastBlock--;
+      bl--;
+    }
+    //-------------------------//
+
+    //--- Adjust first block ---//
+    // While outside of band, advance block
+    while (firstBlock <= lastBlock &&
+           (blocks[firstBlock].score >= k + WORD_SIZE ||
+            ((firstBlock + 1) * WORD_SIZE - 1 <
+             blocks[firstBlock].score - k - targetLength + queryLength + c))) {
+      firstBlock++;
+    }
+    //--------------------------/
+
+    // TODO: consider if this part is useful, it does not seem to help much
+    if (c % STRONG_REDUCE_NUM == 0) { // Every some columns do more expensive
+                                      // but more efficient reduction
+      while (lastBlock >= firstBlock) {
+        // If all cells outside of band, remove block
+        vector<int> scores = getBlockCellValues(*bl);
+        int numCells =
+            lastBlock == maxNumBlocks - 1 ? WORD_SIZE - W : WORD_SIZE;
+        int r = lastBlock * WORD_SIZE + numCells - 1;
+        bool reduce = true;
+        for (int i = WORD_SIZE - numCells; i < WORD_SIZE; i++) {
+          // TODO: Does not work if do not put +1! Why???
+          if (scores[i] <= k &&
+              r <= k - scores[i] - targetLength + c + queryLength + 1) {
+            reduce = false;
+            break;
+          }
+          r--;
+        }
+        if (!reduce)
+          break;
+        lastBlock--;
+        bl--;
+      }
+
+      while (firstBlock <= lastBlock) {
+        // If all cells outside of band, remove block
+        vector<int> scores = getBlockCellValues(blocks[firstBlock]);
+        int numCells =
+            firstBlock == maxNumBlocks - 1 ? WORD_SIZE - W : WORD_SIZE;
+        int r = firstBlock * WORD_SIZE + numCells - 1;
+        bool reduce = true;
+        for (int i = WORD_SIZE - numCells; i < WORD_SIZE; i++) {
+          if (scores[i] <= k &&
+              r >= scores[i] - k - targetLength + c + queryLength) {
+            reduce = false;
+            break;
+          }
+          r--;
+        }
+        if (!reduce)
+          break;
+        firstBlock++;
+      }
+    }
+
+    // If band stops to exist finish
+    if (lastBlock < firstBlock) {
+      *bestScore_ = *position_ = -1;
+      delete[] blocks;
+      return EDLIB_STATUS_OK;
+    }
+    //------------------------------------------------------------------//
+
+    //---- Save column so it can be used for reconstruction ----//
+    if (findAlignment && c < targetLength) {
+      bl = blocks + firstBlock;
+      for (int b = firstBlock; b <= lastBlock; b++) {
+        (*alignData)->Ps[maxNumBlocks * c + b] = bl->P;
+        (*alignData)->Ms[maxNumBlocks * c + b] = bl->M;
+        (*alignData)->scores[maxNumBlocks * c + b] = bl->score;
+        (*alignData)->firstBlocks[c] = firstBlock;
+        (*alignData)->lastBlocks[c] = lastBlock;
+        bl++;
+      }
+    }
+    //----------------------------------------------------------//
+    //---- If this is stop column, save it and finish ----//
+    if (c == targetStopPosition) {
+      for (int b = firstBlock; b <= lastBlock; b++) {
+        (*alignData)->Ps[b] = (blocks + b)->P;
+        (*alignData)->Ms[b] = (blocks + b)->M;
+        (*alignData)->scores[b] = (blocks + b)->score;
+        (*alignData)->firstBlocks[0] = firstBlock;
+        (*alignData)->lastBlocks[0] = lastBlock;
+      }
+      *bestScore_ = -1;
+      *position_ = targetStopPosition;
+      delete[] blocks;
+      return EDLIB_STATUS_OK;
+    }
+    //----------------------------------------------------//
+
+    targetChar++;
+  }
+
+  if (lastBlock ==
+      maxNumBlocks - 1) { // If last block of last column was calculated
+    // Obtain best score from block -> it is complicated because query is padded
+    // with W cells
+    int bestScore = getBlockCellValues(blocks[lastBlock])[W];
+    if (bestScore <= k) {
+      *bestScore_ = bestScore;
+      *position_ = targetLength - 1;
+      delete[] blocks;
+      return EDLIB_STATUS_OK;
+    }
+  }
+
+  *bestScore_ = *position_ = -1;
+  delete[] blocks;
+  return EDLIB_STATUS_OK;
 }
 
-
 /**
- * Finds one possible alignment that gives optimal score by moving back through the dynamic programming matrix,
- * that is stored in alignData. Consumes large amount of memory: O(queryLength * targetLength).
+ * Finds one possible alignment that gives optimal score by moving back through
+ * the dynamic programming matrix, that is stored in alignData. Consumes large
+ * amount of memory: O(queryLength * targetLength).
  * @param [in] queryLength  Normal length, without W.
  * @param [in] targetLength  Normal length, without W.
  * @param [in] bestScore  Best score.
- * @param [in] alignData  Data obtained during finding best score that is useful for finding alignment.
+ * @param [in] alignData  Data obtained during finding best score that is useful
+ * for finding alignment.
  * @param [out] alignment  Alignment.
  * @param [out] alignmentLength  Length of alignment.
  * @return Status code.
  */
-static int obtainAlignmentTraceback(const int queryLength, const int targetLength,
-                                    const int bestScore, const AlignmentData* const alignData,
-                                    unsigned char** const alignment, int* const alignmentLength) {
-    const int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
-    const int W = maxNumBlocks * WORD_SIZE - queryLength;
+static int obtainAlignmentTraceback(const int queryLength,
+                                    const int targetLength, const int bestScore,
+                                    const AlignmentData *const alignData,
+                                    unsigned char **const alignment,
+                                    int *const alignmentLength) {
+  const int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
+  const int W = maxNumBlocks * WORD_SIZE - queryLength;
 
-    *alignment = static_cast<unsigned char*>(malloc((queryLength + targetLength - 1) * sizeof(unsigned char)));
-    *alignmentLength = 0;
-    int c = targetLength - 1; // index of column
-    int b = maxNumBlocks - 1; // index of block in column
-    int currScore = bestScore; // Score of current cell
-    int lScore  = -1; // Score of left cell
-    int uScore  = -1; // Score of upper cell
-    int ulScore = -1; // Score of upper left cell
-    Word currP = alignData->Ps[c * maxNumBlocks + b]; // P of current block
-    Word currM = alignData->Ms[c * maxNumBlocks + b]; // M of current block
-    // True if block to left exists and is in band
-    bool thereIsLeftBlock = c > 0 && b >= alignData->firstBlocks[c-1] && b <= alignData->lastBlocks[c-1];
-    // We set initial values of lP and lM to 0 only to avoid compiler warnings, they should not affect the
-    // calculation as both lP and lM should be initialized at some moment later (but compiler can not
-    // detect it since this initialization is guaranteed by "business" logic).
-    Word lP = 0, lM = 0;
-    if (thereIsLeftBlock) {
-        lP = alignData->Ps[(c - 1) * maxNumBlocks + b]; // P of block to the left
-        lM = alignData->Ms[(c - 1) * maxNumBlocks + b]; // M of block to the left
+  *alignment = static_cast<unsigned char *>(
+      malloc((queryLength + targetLength - 1) * sizeof(unsigned char)));
+  *alignmentLength = 0;
+  int c = targetLength - 1;                         // index of column
+  int b = maxNumBlocks - 1;                         // index of block in column
+  int currScore = bestScore;                        // Score of current cell
+  int lScore = -1;                                  // Score of left cell
+  int uScore = -1;                                  // Score of upper cell
+  int ulScore = -1;                                 // Score of upper left cell
+  Word currP = alignData->Ps[c * maxNumBlocks + b]; // P of current block
+  Word currM = alignData->Ms[c * maxNumBlocks + b]; // M of current block
+  // True if block to left exists and is in band
+  bool thereIsLeftBlock = c > 0 && b >= alignData->firstBlocks[c - 1] &&
+                          b <= alignData->lastBlocks[c - 1];
+  // We set initial values of lP and lM to 0 only to avoid compiler warnings,
+  // they should not affect the calculation as both lP and lM should be
+  // initialized at some moment later (but compiler can not detect it since this
+  // initialization is guaranteed by "business" logic).
+  Word lP = 0, lM = 0;
+  if (thereIsLeftBlock) {
+    lP = alignData->Ps[(c - 1) * maxNumBlocks + b]; // P of block to the left
+    lM = alignData->Ms[(c - 1) * maxNumBlocks + b]; // M of block to the left
+  }
+  currP <<= W;
+  currM <<= W;
+  int blockPos = WORD_SIZE - W - 1; // 0 based index of current cell in blockPos
+
+  // TODO(martin): refactor this whole piece of code. There are too many if-else
+  // statements, it is too easy for a bug to hide and to hard to effectively
+  // cover all the edge-cases. We need better separation of logic and
+  // responsibilities.
+  while (true) {
+    if (c == 0) {
+      thereIsLeftBlock = true;
+      lScore = b * WORD_SIZE + blockPos + 1;
+      ulScore = lScore - 1;
     }
-    currP <<= W;
-    currM <<= W;
-    int blockPos = WORD_SIZE - W - 1; // 0 based index of current cell in blockPos
 
-    // TODO(martin): refactor this whole piece of code. There are too many if-else statements,
-    // it is too easy for a bug to hide and to hard to effectively cover all the edge-cases.
-    // We need better separation of logic and responsibilities.
-    while (true) {
-        if (c == 0) {
-            thereIsLeftBlock = true;
-            lScore = b * WORD_SIZE + blockPos + 1;
-            ulScore = lScore - 1;
-        }
+    // TODO: improvement: calculate only those cells that are needed,
+    //       for example if I calculate upper cell and can move up,
+    //       there is no need to calculate left and upper left cell
+    //---------- Calculate scores ---------//
+    if (lScore == -1 && thereIsLeftBlock) {
+      lScore = alignData->scores[(c - 1) * maxNumBlocks +
+                                 b]; // score of block to the left
+      for (int i = 0; i < WORD_SIZE - blockPos - 1; i++) {
+        if (lP & HIGH_BIT_MASK)
+          lScore--;
+        if (lM & HIGH_BIT_MASK)
+          lScore++;
+        lP <<= 1;
+        lM <<= 1;
+      }
+    }
+    if (ulScore == -1) {
+      if (lScore != -1) {
+        ulScore = lScore;
+        if (lP & HIGH_BIT_MASK)
+          ulScore--;
+        if (lM & HIGH_BIT_MASK)
+          ulScore++;
+      } else if (c > 0 && b - 1 >= alignData->firstBlocks[c - 1] &&
+                 b - 1 <= alignData->lastBlocks[c - 1]) {
+        // This is the case when upper left cell is last cell in block,
+        // and block to left is not in band so lScore is -1.
+        ulScore = alignData->scores[(c - 1) * maxNumBlocks + b - 1];
+      }
+    }
+    if (uScore == -1) {
+      uScore = currScore;
+      if (currP & HIGH_BIT_MASK)
+        uScore--;
+      if (currM & HIGH_BIT_MASK)
+        uScore++;
+      currP <<= 1;
+      currM <<= 1;
+    }
+    //-------------------------------------//
 
-        // TODO: improvement: calculate only those cells that are needed,
-        //       for example if I calculate upper cell and can move up,
-        //       there is no need to calculate left and upper left cell
-        //---------- Calculate scores ---------//
-        if (lScore == -1 && thereIsLeftBlock) {
-            lScore = alignData->scores[(c - 1) * maxNumBlocks + b]; // score of block to the left
-            for (int i = 0; i < WORD_SIZE - blockPos - 1; i++) {
-                if (lP & HIGH_BIT_MASK) lScore--;
-                if (lM & HIGH_BIT_MASK) lScore++;
-                lP <<= 1;
-                lM <<= 1;
-            }
-        }
-        if (ulScore == -1) {
-            if (lScore != -1) {
-                ulScore = lScore;
-                if (lP & HIGH_BIT_MASK) ulScore--;
-                if (lM & HIGH_BIT_MASK) ulScore++;
-            }
-            else if (c > 0 && b-1 >= alignData->firstBlocks[c-1] && b-1 <= alignData->lastBlocks[c-1]) {
-                // This is the case when upper left cell is last cell in block,
-                // and block to left is not in band so lScore is -1.
-                ulScore = alignData->scores[(c - 1) * maxNumBlocks + b - 1];
-            }
-        }
-        if (uScore == -1) {
-            uScore = currScore;
-            if (currP & HIGH_BIT_MASK) uScore--;
-            if (currM & HIGH_BIT_MASK) uScore++;
-            currP <<= 1;
-            currM <<= 1;
-        }
-        //-------------------------------------//
+    // TODO: should I check if there is upper block?
 
-        // TODO: should I check if there is upper block?
-
-        //-------------- Move --------------//
-        // Move up - insertion to target - deletion from query
-        if (uScore != -1 && uScore + 1 == currScore) {
-            currScore = uScore;
-            lScore = ulScore;
-            uScore = ulScore = -1;
-            if (blockPos == 0) { // If entering new (upper) block
-                if (b == 0) { // If there are no cells above (only boundary cells)
-                    (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_INSERT; // Move up
-                    for (int i = 0; i < c + 1; i++) // Move left until end
-                        (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_DELETE;
-                    break;
-                } else {
-                    blockPos = WORD_SIZE - 1;
-                    b--;
-                    currP = alignData->Ps[c * maxNumBlocks + b];
-                    currM = alignData->Ms[c * maxNumBlocks + b];
-                    if (c > 0 && b >= alignData->firstBlocks[c-1] && b <= alignData->lastBlocks[c-1]) {
-                        thereIsLeftBlock = true;
-                        lP = alignData->Ps[(c - 1) * maxNumBlocks + b]; // TODO: improve this, too many operations
-                        lM = alignData->Ms[(c - 1) * maxNumBlocks + b];
-                    } else {
-                        thereIsLeftBlock = false;
-                        // TODO(martin): There may not be left block, but there can be left boundary - do we
-                        // handle this correctly then? Are l and ul score set correctly? I should check that / refactor this.
-                    }
-                }
-            } else {
-                blockPos--;
-                lP <<= 1;
-                lM <<= 1;
-            }
-            // Mark move
-            (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_INSERT;
-        }
-        // Move left - deletion from target - insertion to query
-        else if (lScore != -1 && lScore + 1 == currScore) {
-            currScore = lScore;
-            uScore = ulScore;
-            lScore = ulScore = -1;
-            c--;
-            if (c == -1) { // If there are no cells to the left (only boundary cells)
-                (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_DELETE; // Move left
-                int numUp = b * WORD_SIZE + blockPos + 1;
-                for (int i = 0; i < numUp; i++) // Move up until end
-                    (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_INSERT;
-                break;
-            }
-            currP = lP;
-            currM = lM;
-            if (c > 0 && b >= alignData->firstBlocks[c-1] && b <= alignData->lastBlocks[c-1]) {
-                thereIsLeftBlock = true;
-                lP = alignData->Ps[(c - 1) * maxNumBlocks + b];
-                lM = alignData->Ms[(c - 1) * maxNumBlocks + b];
-            } else {
-                if (c == 0) { // If there are no cells to the left (only boundary cells)
-                    thereIsLeftBlock = true;
-                    lScore = b * WORD_SIZE + blockPos + 1;
-                    ulScore = lScore - 1;
-                } else {
-                    thereIsLeftBlock = false;
-                }
-            }
-            // Mark move
+    //-------------- Move --------------//
+    // Move up - insertion to target - deletion from query
+    if (uScore != -1 && uScore + 1 == currScore) {
+      currScore = uScore;
+      lScore = ulScore;
+      uScore = ulScore = -1;
+      if (blockPos == 0) { // If entering new (upper) block
+        if (b == 0) {      // If there are no cells above (only boundary cells)
+          (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_INSERT; // Move up
+          for (int i = 0; i < c + 1; i++) // Move left until end
             (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_DELETE;
-        }
-        // Move up left - (mis)match
-        else if (ulScore != -1) {
-            unsigned char moveCode = ulScore == currScore ? EDLIB_EDOP_MATCH : EDLIB_EDOP_MISMATCH;
-            currScore = ulScore;
-            uScore = lScore = ulScore = -1;
-            c--;
-            if (c == -1) { // If there are no cells to the left (only boundary cells)
-                (*alignment)[(*alignmentLength)++] = moveCode; // Move left
-                int numUp = b * WORD_SIZE + blockPos;
-                for (int i = 0; i < numUp; i++) // Move up until end
-                    (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_INSERT;
-                break;
-            }
-            if (blockPos == 0) { // If entering upper left block
-                if (b == 0) { // If there are no more cells above (only boundary cells)
-                    (*alignment)[(*alignmentLength)++] = moveCode; // Move up left
-                    for (int i = 0; i < c + 1; i++) // Move left until end
-                        (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_DELETE;
-                    break;
-                }
-                blockPos = WORD_SIZE - 1;
-                b--;
-                currP = alignData->Ps[c * maxNumBlocks + b];
-                currM = alignData->Ms[c * maxNumBlocks + b];
-            } else { // If entering left block
-                blockPos--;
-                currP = lP;
-                currM = lM;
-                currP <<= 1;
-                currM <<= 1;
-            }
-            // Set new left block
-            if (c > 0 && b >= alignData->firstBlocks[c-1] && b <= alignData->lastBlocks[c-1]) {
-                thereIsLeftBlock = true;
-                lP = alignData->Ps[(c - 1) * maxNumBlocks + b];
-                lM = alignData->Ms[(c - 1) * maxNumBlocks + b];
-            } else {
-                if (c == 0) { // If there are no cells to the left (only boundary cells)
-                    thereIsLeftBlock = true;
-                    lScore = b * WORD_SIZE + blockPos + 1;
-                    ulScore = lScore - 1;
-                } else {
-                    thereIsLeftBlock = false;
-                }
-            }
-            // Mark move
-            (*alignment)[(*alignmentLength)++] = moveCode;
+          break;
         } else {
-            // Reached end - finished!
-            break;
+          blockPos = WORD_SIZE - 1;
+          b--;
+          currP = alignData->Ps[c * maxNumBlocks + b];
+          currM = alignData->Ms[c * maxNumBlocks + b];
+          if (c > 0 && b >= alignData->firstBlocks[c - 1] &&
+              b <= alignData->lastBlocks[c - 1]) {
+            thereIsLeftBlock = true;
+            lP = alignData->Ps[(c - 1) * maxNumBlocks +
+                               b]; // TODO: improve this, too many operations
+            lM = alignData->Ms[(c - 1) * maxNumBlocks + b];
+          } else {
+            thereIsLeftBlock = false;
+            // TODO(martin): There may not be left block, but there can be left
+            // boundary - do we handle this correctly then? Are l and ul score
+            // set correctly? I should check that / refactor this.
+          }
         }
-        //----------------------------------//
+      } else {
+        blockPos--;
+        lP <<= 1;
+        lM <<= 1;
+      }
+      // Mark move
+      (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_INSERT;
     }
+    // Move left - deletion from target - insertion to query
+    else if (lScore != -1 && lScore + 1 == currScore) {
+      currScore = lScore;
+      uScore = ulScore;
+      lScore = ulScore = -1;
+      c--;
+      if (c == -1) { // If there are no cells to the left (only boundary cells)
+        (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_DELETE; // Move left
+        int numUp = b * WORD_SIZE + blockPos + 1;
+        for (int i = 0; i < numUp; i++) // Move up until end
+          (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_INSERT;
+        break;
+      }
+      currP = lP;
+      currM = lM;
+      if (c > 0 && b >= alignData->firstBlocks[c - 1] &&
+          b <= alignData->lastBlocks[c - 1]) {
+        thereIsLeftBlock = true;
+        lP = alignData->Ps[(c - 1) * maxNumBlocks + b];
+        lM = alignData->Ms[(c - 1) * maxNumBlocks + b];
+      } else {
+        if (c == 0) { // If there are no cells to the left (only boundary cells)
+          thereIsLeftBlock = true;
+          lScore = b * WORD_SIZE + blockPos + 1;
+          ulScore = lScore - 1;
+        } else {
+          thereIsLeftBlock = false;
+        }
+      }
+      // Mark move
+      (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_DELETE;
+    }
+    // Move up left - (mis)match
+    else if (ulScore != -1) {
+      unsigned char moveCode =
+          ulScore == currScore ? EDLIB_EDOP_MATCH : EDLIB_EDOP_MISMATCH;
+      currScore = ulScore;
+      uScore = lScore = ulScore = -1;
+      c--;
+      if (c == -1) { // If there are no cells to the left (only boundary cells)
+        (*alignment)[(*alignmentLength)++] = moveCode; // Move left
+        int numUp = b * WORD_SIZE + blockPos;
+        for (int i = 0; i < numUp; i++) // Move up until end
+          (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_INSERT;
+        break;
+      }
+      if (blockPos == 0) { // If entering upper left block
+        if (b == 0) { // If there are no more cells above (only boundary cells)
+          (*alignment)[(*alignmentLength)++] = moveCode; // Move up left
+          for (int i = 0; i < c + 1; i++)                // Move left until end
+            (*alignment)[(*alignmentLength)++] = EDLIB_EDOP_DELETE;
+          break;
+        }
+        blockPos = WORD_SIZE - 1;
+        b--;
+        currP = alignData->Ps[c * maxNumBlocks + b];
+        currM = alignData->Ms[c * maxNumBlocks + b];
+      } else { // If entering left block
+        blockPos--;
+        currP = lP;
+        currM = lM;
+        currP <<= 1;
+        currM <<= 1;
+      }
+      // Set new left block
+      if (c > 0 && b >= alignData->firstBlocks[c - 1] &&
+          b <= alignData->lastBlocks[c - 1]) {
+        thereIsLeftBlock = true;
+        lP = alignData->Ps[(c - 1) * maxNumBlocks + b];
+        lM = alignData->Ms[(c - 1) * maxNumBlocks + b];
+      } else {
+        if (c == 0) { // If there are no cells to the left (only boundary cells)
+          thereIsLeftBlock = true;
+          lScore = b * WORD_SIZE + blockPos + 1;
+          ulScore = lScore - 1;
+        } else {
+          thereIsLeftBlock = false;
+        }
+      }
+      // Mark move
+      (*alignment)[(*alignmentLength)++] = moveCode;
+    } else {
+      // Reached end - finished!
+      break;
+    }
+    //----------------------------------//
+  }
 
-    *alignment = static_cast<unsigned char*>(realloc(*alignment, (*alignmentLength) * sizeof(unsigned char)));
-    reverse(*alignment, *alignment + (*alignmentLength));
-    return EDLIB_STATUS_OK;
+  *alignment = static_cast<unsigned char *>(
+      realloc(*alignment, (*alignmentLength) * sizeof(unsigned char)));
+  reverse(*alignment, *alignment + (*alignmentLength));
+  return EDLIB_STATUS_OK;
 }
-
 
 /**
  * Finds one possible alignment that gives optimal score (bestScore).
- * It will split problem into smaller problems using Hirschberg's algorithm and when they are small enough,
- * it will solve them using traceback algorithm.
+ * It will split problem into smaller problems using Hirschberg's algorithm and
+ * when they are small enough, it will solve them using traceback algorithm.
  * @param [in] query
  * @param [in] rQuery  Reversed query.
  * @param [in] queryLength
@@ -1157,68 +1267,78 @@ static int obtainAlignmentTraceback(const int queryLength, const int targetLengt
  * @param [in] equalityDefinition
  * @param [in] alphabetLength
  * @param [in] bestScore  Best(optimal) score.
- * @param [out] alignment  Sequence of edit operations that make target equal to query.
+ * @param [out] alignment  Sequence of edit operations that make target equal to
+ * query.
  * @param [out] alignmentLength  Length of alignment.
  * @return Status code.
  */
-static int obtainAlignment(
-        const unsigned char* const query, const unsigned char* const rQuery, const int queryLength,
-        const unsigned char* const target, const unsigned char* const rTarget, const int targetLength,
-        const EqualityDefinition& equalityDefinition, const int alphabetLength, const int bestScore,
-        unsigned char** const alignment, int* const alignmentLength) {
+static int
+obtainAlignment(const unsigned char *const query,
+                const unsigned char *const rQuery, const int queryLength,
+                const unsigned char *const target,
+                const unsigned char *const rTarget, const int targetLength,
+                const EqualityDefinition &equalityDefinition,
+                const int alphabetLength, const int bestScore,
+                unsigned char **const alignment, int *const alignmentLength) {
 
-    // Handle special case when one of sequences has length of 0.
-    if (queryLength == 0 || targetLength == 0) {
-        *alignmentLength = targetLength + queryLength;
-        *alignment = static_cast<unsigned char*>(malloc((*alignmentLength) * sizeof(unsigned char)));
-        for (int i = 0; i < *alignmentLength; i++) {
-            (*alignment)[i] = queryLength == 0 ? EDLIB_EDOP_DELETE : EDLIB_EDOP_INSERT;
-        }
-        return EDLIB_STATUS_OK;
+  // Handle special case when one of sequences has length of 0.
+  if (queryLength == 0 || targetLength == 0) {
+    *alignmentLength = targetLength + queryLength;
+    *alignment = static_cast<unsigned char *>(
+        malloc((*alignmentLength) * sizeof(unsigned char)));
+    for (int i = 0; i < *alignmentLength; i++) {
+      (*alignment)[i] =
+          queryLength == 0 ? EDLIB_EDOP_DELETE : EDLIB_EDOP_INSERT;
     }
+    return EDLIB_STATUS_OK;
+  }
 
-    const int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
-    const int W = maxNumBlocks * WORD_SIZE - queryLength;
-    int statusCode;
+  const int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
+  const int W = maxNumBlocks * WORD_SIZE - queryLength;
+  int statusCode;
 
-    // TODO: think about reducing number of memory allocations in alignment functions, probably
-    // by sharing some memory that is allocated only once. That refers to: Peq, columns in Hirschberg,
-    // and it could also be done for alignments - we could have one big array for alignment that would be
-    // sparsely populated by each of steps in recursion, and at the end we would just consolidate those results.
+  // TODO: think about reducing number of memory allocations in alignment
+  // functions, probably by sharing some memory that is allocated only once.
+  // That refers to: Peq, columns in Hirschberg, and it could also be done for
+  // alignments - we could have one big array for alignment that would be
+  // sparsely populated by each of steps in recursion, and at the end we would
+  // just consolidate those results.
 
-    // If estimated memory consumption for traceback algorithm is smaller than 1MB use it,
-    // otherwise use Hirschberg's algorithm. By running few tests I choose boundary of 1MB as optimal.
-    long long alignmentDataSize = (2ll * sizeof(Word) + sizeof(int)) * maxNumBlocks * targetLength
-        + 2ll * sizeof(int) * targetLength;
-    if (alignmentDataSize < 1024 * 1024) {
-        int score_, endLocation_;  // Used only to call function.
-        AlignmentData* alignData = NULL;
-        Word* Peq = buildPeq(alphabetLength, query, queryLength, equalityDefinition);
-        myersCalcEditDistanceNW(Peq, W, maxNumBlocks,
-                                queryLength,
-                                target, targetLength,
-                                bestScore,
-                                &score_, &endLocation_, true, &alignData, -1);
-        //assert(score_ == bestScore);
-        //assert(endLocation_ == targetLength - 1);
+  // If estimated memory consumption for traceback algorithm is smaller than 1MB
+  // use it, otherwise use Hirschberg's algorithm. By running few tests I choose
+  // boundary of 1MB as optimal.
+  long long alignmentDataSize =
+      (2ll * sizeof(Word) + sizeof(int)) * maxNumBlocks * targetLength +
+      2ll * sizeof(int) * targetLength;
+  if (alignmentDataSize < 1024 * 1024) {
+    int score_, endLocation_; // Used only to call function.
+    AlignmentData *alignData = NULL;
+    Word *Peq =
+        buildPeq(alphabetLength, query, queryLength, equalityDefinition);
+    myersCalcEditDistanceNW(Peq, W, maxNumBlocks, queryLength, target,
+                            targetLength, bestScore, &score_, &endLocation_,
+                            true, &alignData, -1);
+    // assert(score_ == bestScore);
+    // assert(endLocation_ == targetLength - 1);
 
-        statusCode = obtainAlignmentTraceback(queryLength, targetLength,
-                                              bestScore, alignData, alignment, alignmentLength);
-        delete alignData;
-        delete[] Peq;
-    } else {
-        statusCode = obtainAlignmentHirschberg(query, rQuery, queryLength,
-                                               target, rTarget, targetLength,
-                                               equalityDefinition, alphabetLength, bestScore,
-                                               alignment, alignmentLength);
-    }
-    return statusCode;
+    statusCode =
+        obtainAlignmentTraceback(queryLength, targetLength, bestScore,
+                                 alignData, alignment, alignmentLength);
+    delete alignData;
+    delete[] Peq;
+  } else {
+    statusCode = obtainAlignmentHirschberg(
+        query, rQuery, queryLength, target, rTarget, targetLength,
+        equalityDefinition, alphabetLength, bestScore, alignment,
+        alignmentLength);
+  }
+  return statusCode;
 }
-
 
 /**
  * Finds one possible alignment that gives optimal score (bestScore).
- * Uses Hirschberg's algorithm to split problem into two sub-problems, solve them and combine them together.
+ * Uses Hirschberg's algorithm to split problem into two sub-problems, solve
+ * them and combine them together.
  * @param [in] query
  * @param [in] rQuery  Reversed query.
  * @param [in] queryLength
@@ -1227,183 +1347,210 @@ static int obtainAlignment(
  * @param [in] targetLength
  * @param [in] alphabetLength
  * @param [in] bestScore  Best(optimal) score.
- * @param [out] alignment  Sequence of edit operations that make target equal to query.
+ * @param [out] alignment  Sequence of edit operations that make target equal to
+ * query.
  * @param [out] alignmentLength  Length of alignment.
  * @return Status code.
  */
 static int obtainAlignmentHirschberg(
-        const unsigned char* const query, const unsigned char* const rQuery, const int queryLength,
-        const unsigned char* const target, const unsigned char* const rTarget, const int targetLength,
-        const EqualityDefinition& equalityDefinition, const int alphabetLength, const int bestScore,
-        unsigned char** const alignment, int* const alignmentLength) {
+    const unsigned char *const query, const unsigned char *const rQuery,
+    const int queryLength, const unsigned char *const target,
+    const unsigned char *const rTarget, const int targetLength,
+    const EqualityDefinition &equalityDefinition, const int alphabetLength,
+    const int bestScore, unsigned char **const alignment,
+    int *const alignmentLength) {
 
-    const int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
-    const int W = maxNumBlocks * WORD_SIZE - queryLength;
+  const int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
+  const int W = maxNumBlocks * WORD_SIZE - queryLength;
 
-    Word* Peq = buildPeq(alphabetLength, query, queryLength, equalityDefinition);
-    Word* rPeq = buildPeq(alphabetLength, rQuery, queryLength, equalityDefinition);
+  Word *Peq = buildPeq(alphabetLength, query, queryLength, equalityDefinition);
+  Word *rPeq =
+      buildPeq(alphabetLength, rQuery, queryLength, equalityDefinition);
 
-    // Used only to call functions.
-    int score_, endLocation_;
+  // Used only to call functions.
+  int score_, endLocation_;
 
-    // Divide dynamic matrix into two halfs, left and right.
-    const int leftHalfWidth = targetLength / 2;
-    const int rightHalfWidth = targetLength - leftHalfWidth;
+  // Divide dynamic matrix into two halfs, left and right.
+  const int leftHalfWidth = targetLength / 2;
+  const int rightHalfWidth = targetLength - leftHalfWidth;
 
-    // Calculate left half.
-    AlignmentData* alignDataLeftHalf = NULL;
-    int leftHalfCalcStatus = myersCalcEditDistanceNW(
-            Peq, W, maxNumBlocks, queryLength, target, targetLength, bestScore,
-            &score_, &endLocation_, false, &alignDataLeftHalf, leftHalfWidth - 1);
+  // Calculate left half.
+  AlignmentData *alignDataLeftHalf = NULL;
+  int leftHalfCalcStatus = myersCalcEditDistanceNW(
+      Peq, W, maxNumBlocks, queryLength, target, targetLength, bestScore,
+      &score_, &endLocation_, false, &alignDataLeftHalf, leftHalfWidth - 1);
 
-    // Calculate right half.
-    AlignmentData* alignDataRightHalf = NULL;
-    int rightHalfCalcStatus = myersCalcEditDistanceNW(
-            rPeq, W, maxNumBlocks, queryLength, rTarget, targetLength, bestScore,
-            &score_, &endLocation_, false, &alignDataRightHalf, rightHalfWidth - 1);
+  // Calculate right half.
+  AlignmentData *alignDataRightHalf = NULL;
+  int rightHalfCalcStatus = myersCalcEditDistanceNW(
+      rPeq, W, maxNumBlocks, queryLength, rTarget, targetLength, bestScore,
+      &score_, &endLocation_, false, &alignDataRightHalf, rightHalfWidth - 1);
 
-    delete[] Peq;
-    delete[] rPeq;
+  delete[] Peq;
+  delete[] rPeq;
 
-    if (leftHalfCalcStatus == EDLIB_STATUS_ERROR || rightHalfCalcStatus == EDLIB_STATUS_ERROR) {
-        if (alignDataLeftHalf) delete alignDataLeftHalf;
-        if (alignDataRightHalf) delete alignDataRightHalf;
-        return EDLIB_STATUS_ERROR;
+  if (leftHalfCalcStatus == EDLIB_STATUS_ERROR ||
+      rightHalfCalcStatus == EDLIB_STATUS_ERROR) {
+    if (alignDataLeftHalf)
+      delete alignDataLeftHalf;
+    if (alignDataRightHalf)
+      delete alignDataRightHalf;
+    return EDLIB_STATUS_ERROR;
+  }
+
+  // Unwrap the left half.
+  int firstBlockIdxLeft = alignDataLeftHalf->firstBlocks[0];
+  int lastBlockIdxLeft = alignDataLeftHalf->lastBlocks[0];
+  // TODO: avoid this allocation by using some shared array?
+  // scoresLeft contains scores from left column, starting with
+  // scoresLeftStartIdx row (query index) and ending with scoresLeftEndIdx row
+  // (0-indexed).
+  int scoresLeftLength = (lastBlockIdxLeft - firstBlockIdxLeft + 1) * WORD_SIZE;
+  int *scoresLeft = new int[scoresLeftLength];
+  for (int blockIdx = firstBlockIdxLeft; blockIdx <= lastBlockIdxLeft;
+       blockIdx++) {
+    Block block(alignDataLeftHalf->Ps[blockIdx],
+                alignDataLeftHalf->Ms[blockIdx],
+                alignDataLeftHalf->scores[blockIdx]);
+    readBlock(block, scoresLeft + (blockIdx - firstBlockIdxLeft) * WORD_SIZE);
+  }
+  int scoresLeftStartIdx = firstBlockIdxLeft * WORD_SIZE;
+  // If last block contains padding, shorten the length of scores for the length
+  // of padding.
+  if (lastBlockIdxLeft == maxNumBlocks - 1) {
+    scoresLeftLength -= W;
+  }
+
+  // Unwrap the right half (I also reverse it while unwraping).
+  int firstBlockIdxRight = alignDataRightHalf->firstBlocks[0];
+  int lastBlockIdxRight = alignDataRightHalf->lastBlocks[0];
+  int scoresRightLength =
+      (lastBlockIdxRight - firstBlockIdxRight + 1) * WORD_SIZE;
+  int *scoresRight = new int[scoresRightLength];
+  int *scoresRightOriginalStart = scoresRight;
+  for (int blockIdx = firstBlockIdxRight; blockIdx <= lastBlockIdxRight;
+       blockIdx++) {
+    Block block(alignDataRightHalf->Ps[blockIdx],
+                alignDataRightHalf->Ms[blockIdx],
+                alignDataRightHalf->scores[blockIdx]);
+    readBlockReverse(block,
+                     scoresRight + (lastBlockIdxRight - blockIdx) * WORD_SIZE);
+  }
+  int scoresRightStartIdx = queryLength - (lastBlockIdxRight + 1) * WORD_SIZE;
+  // If there is padding at the beginning of scoresRight (that can happen
+  // because of reversing that we do), move pointer forward to remove the
+  // padding (that is why we remember originalStart).
+  if (scoresRightStartIdx < 0) {
+    // assert(scoresRightStartIdx == -1 * W);
+    scoresRight += W;
+    scoresRightStartIdx += W;
+    scoresRightLength -= W;
+  }
+
+  delete alignDataLeftHalf;
+  delete alignDataRightHalf;
+
+  //--------------------- Find the best move ----------------//
+  // Find the query/row index of cell in left column which together with its
+  // lower right neighbour from right column gives the best score (when summed).
+  // We also have to consider boundary cells (those cells at -1 indexes).
+  //  x|
+  //  -+-
+  //   |x
+  int queryIdxLeftStart = max(scoresLeftStartIdx, scoresRightStartIdx - 1);
+  int queryIdxLeftEnd = min(scoresLeftStartIdx + scoresLeftLength - 1,
+                            scoresRightStartIdx + scoresRightLength - 2);
+  int leftScore = -1, rightScore = -1;
+  int queryIdxLeftAlignment = -1; // Query/row index of cell in left column
+                                  // where alignment is passing through.
+  bool queryIdxLeftAlignmentFound = false;
+  for (int queryIdx = queryIdxLeftStart; queryIdx <= queryIdxLeftEnd;
+       queryIdx++) {
+    leftScore = scoresLeft[queryIdx - scoresLeftStartIdx];
+    rightScore = scoresRight[queryIdx + 1 - scoresRightStartIdx];
+    if (leftScore + rightScore == bestScore) {
+      queryIdxLeftAlignment = queryIdx;
+      queryIdxLeftAlignmentFound = true;
+      break;
     }
-
-    // Unwrap the left half.
-    int firstBlockIdxLeft = alignDataLeftHalf->firstBlocks[0];
-    int lastBlockIdxLeft = alignDataLeftHalf->lastBlocks[0];
-    // TODO: avoid this allocation by using some shared array?
-    // scoresLeft contains scores from left column, starting with scoresLeftStartIdx row (query index)
-    // and ending with scoresLeftEndIdx row (0-indexed).
-    int scoresLeftLength = (lastBlockIdxLeft - firstBlockIdxLeft + 1) * WORD_SIZE;
-    int* scoresLeft = new int[scoresLeftLength];
-    for (int blockIdx = firstBlockIdxLeft; blockIdx <= lastBlockIdxLeft; blockIdx++) {
-        Block block(alignDataLeftHalf->Ps[blockIdx], alignDataLeftHalf->Ms[blockIdx],
-                    alignDataLeftHalf->scores[blockIdx]);
-        readBlock(block, scoresLeft + (blockIdx - firstBlockIdxLeft) * WORD_SIZE);
+  }
+  // Check boundary cells.
+  if (!queryIdxLeftAlignmentFound && scoresLeftStartIdx == 0 &&
+      scoresRightStartIdx == 0) {
+    leftScore = leftHalfWidth;
+    rightScore = scoresRight[0];
+    if (leftScore + rightScore == bestScore) {
+      queryIdxLeftAlignment = -1;
+      queryIdxLeftAlignmentFound = true;
     }
-    int scoresLeftStartIdx = firstBlockIdxLeft * WORD_SIZE;
-    // If last block contains padding, shorten the length of scores for the length of padding.
-    if (lastBlockIdxLeft == maxNumBlocks - 1) {
-        scoresLeftLength -= W;
+  }
+  if (!queryIdxLeftAlignmentFound &&
+      scoresLeftStartIdx + scoresLeftLength == queryLength &&
+      scoresRightStartIdx + scoresRightLength == queryLength) {
+    leftScore = scoresLeft[scoresLeftLength - 1];
+    rightScore = rightHalfWidth;
+    if (leftScore + rightScore == bestScore) {
+      queryIdxLeftAlignment = queryLength - 1;
+      queryIdxLeftAlignmentFound = true;
     }
+  }
 
-    // Unwrap the right half (I also reverse it while unwraping).
-    int firstBlockIdxRight = alignDataRightHalf->firstBlocks[0];
-    int lastBlockIdxRight = alignDataRightHalf->lastBlocks[0];
-    int scoresRightLength = (lastBlockIdxRight - firstBlockIdxRight + 1) * WORD_SIZE;
-    int* scoresRight = new int[scoresRightLength];
-    int* scoresRightOriginalStart = scoresRight;
-    for (int blockIdx = firstBlockIdxRight; blockIdx <= lastBlockIdxRight; blockIdx++) {
-        Block block(alignDataRightHalf->Ps[blockIdx], alignDataRightHalf->Ms[blockIdx],
-                    alignDataRightHalf->scores[blockIdx]);
-        readBlockReverse(block, scoresRight + (lastBlockIdxRight - blockIdx) * WORD_SIZE);
-    }
-    int scoresRightStartIdx = queryLength - (lastBlockIdxRight + 1) * WORD_SIZE;
-    // If there is padding at the beginning of scoresRight (that can happen because of reversing that we do),
-    // move pointer forward to remove the padding (that is why we remember originalStart).
-    if (scoresRightStartIdx < 0) {
-        //assert(scoresRightStartIdx == -1 * W);
-        scoresRight += W;
-        scoresRightStartIdx += W;
-        scoresRightLength -= W;
-    }
+  delete[] scoresLeft;
+  delete[] scoresRightOriginalStart;
 
-    delete alignDataLeftHalf;
-    delete alignDataRightHalf;
+  if (queryIdxLeftAlignmentFound == false) {
+    // If there was no move that is part of optimal alignment, then there is no
+    // such alignment or given bestScore is not correct!
+    return EDLIB_STATUS_ERROR;
+  }
+  //----------------------------------------------------------//
 
-    //--------------------- Find the best move ----------------//
-    // Find the query/row index of cell in left column which together with its lower right neighbour
-    // from right column gives the best score (when summed). We also have to consider boundary cells
-    // (those cells at -1 indexes).
-    //  x|
-    //  -+-
-    //   |x
-    int queryIdxLeftStart = max(scoresLeftStartIdx, scoresRightStartIdx - 1);
-    int queryIdxLeftEnd = min(scoresLeftStartIdx + scoresLeftLength - 1,
-                          scoresRightStartIdx + scoresRightLength - 2);
-    int leftScore = -1, rightScore = -1;
-    int queryIdxLeftAlignment = -1;  // Query/row index of cell in left column where alignment is passing through.
-    bool queryIdxLeftAlignmentFound = false;
-    for (int queryIdx = queryIdxLeftStart; queryIdx <= queryIdxLeftEnd; queryIdx++) {
-        leftScore = scoresLeft[queryIdx - scoresLeftStartIdx];
-        rightScore = scoresRight[queryIdx + 1 - scoresRightStartIdx];
-        if (leftScore + rightScore == bestScore) {
-            queryIdxLeftAlignment = queryIdx;
-            queryIdxLeftAlignmentFound = true;
-            break;
-        }
-    }
-    // Check boundary cells.
-    if (!queryIdxLeftAlignmentFound && scoresLeftStartIdx == 0 && scoresRightStartIdx == 0) {
-        leftScore = leftHalfWidth;
-        rightScore = scoresRight[0];
-        if (leftScore + rightScore == bestScore) {
-            queryIdxLeftAlignment = -1;
-            queryIdxLeftAlignmentFound = true;
-        }
-    }
-    if (!queryIdxLeftAlignmentFound && scoresLeftStartIdx + scoresLeftLength == queryLength
-        && scoresRightStartIdx + scoresRightLength == queryLength) {
-        leftScore = scoresLeft[scoresLeftLength - 1];
-        rightScore = rightHalfWidth;
-        if (leftScore + rightScore == bestScore) {
-            queryIdxLeftAlignment = queryLength - 1;
-            queryIdxLeftAlignmentFound = true;
-        }
-    }
+  // Calculate alignments for upper half of left half (upper left - ul)
+  // and lower half of right half (lower right - lr).
+  const int ulHeight = queryIdxLeftAlignment + 1;
+  const int lrHeight = queryLength - ulHeight;
+  const int ulWidth = leftHalfWidth;
+  const int lrWidth = rightHalfWidth;
+  unsigned char *ulAlignment = NULL;
+  int ulAlignmentLength;
+  int ulStatusCode = obtainAlignment(
+      query, rQuery + lrHeight, ulHeight, target, rTarget + lrWidth, ulWidth,
+      equalityDefinition, alphabetLength, leftScore, &ulAlignment,
+      &ulAlignmentLength);
+  unsigned char *lrAlignment = NULL;
+  int lrAlignmentLength;
+  int lrStatusCode =
+      obtainAlignment(query + ulHeight, rQuery, lrHeight, target + ulWidth,
+                      rTarget, lrWidth, equalityDefinition, alphabetLength,
+                      rightScore, &lrAlignment, &lrAlignmentLength);
+  if (ulStatusCode == EDLIB_STATUS_ERROR ||
+      lrStatusCode == EDLIB_STATUS_ERROR) {
+    if (ulAlignment)
+      free(ulAlignment);
+    if (lrAlignment)
+      free(lrAlignment);
+    return EDLIB_STATUS_ERROR;
+  }
 
-    delete[] scoresLeft;
-    delete[] scoresRightOriginalStart;
+  // Build alignment by concatenating upper left alignment with lower right
+  // alignment.
+  *alignmentLength = ulAlignmentLength + lrAlignmentLength;
+  *alignment = static_cast<unsigned char *>(
+      malloc((*alignmentLength) * sizeof(unsigned char)));
+  memcpy(*alignment, ulAlignment, ulAlignmentLength);
+  memcpy(*alignment + ulAlignmentLength, lrAlignment, lrAlignmentLength);
 
-    if (queryIdxLeftAlignmentFound == false) {
-        // If there was no move that is part of optimal alignment, then there is no such alignment
-        // or given bestScore is not correct!
-        return EDLIB_STATUS_ERROR;
-    }
-    //----------------------------------------------------------//
-
-    // Calculate alignments for upper half of left half (upper left - ul)
-    // and lower half of right half (lower right - lr).
-    const int ulHeight = queryIdxLeftAlignment + 1;
-    const int lrHeight = queryLength - ulHeight;
-    const int ulWidth = leftHalfWidth;
-    const int lrWidth = rightHalfWidth;
-    unsigned char* ulAlignment = NULL; int ulAlignmentLength;
-    int ulStatusCode = obtainAlignment(query, rQuery + lrHeight, ulHeight,
-                                       target, rTarget + lrWidth, ulWidth,
-                                       equalityDefinition, alphabetLength, leftScore,
-                                       &ulAlignment, &ulAlignmentLength);
-    unsigned char* lrAlignment = NULL; int lrAlignmentLength;
-    int lrStatusCode = obtainAlignment(query + ulHeight, rQuery, lrHeight,
-                                       target + ulWidth, rTarget, lrWidth,
-                                       equalityDefinition, alphabetLength, rightScore,
-                                       &lrAlignment, &lrAlignmentLength);
-    if (ulStatusCode == EDLIB_STATUS_ERROR || lrStatusCode == EDLIB_STATUS_ERROR) {
-        if (ulAlignment) free(ulAlignment);
-        if (lrAlignment) free(lrAlignment);
-        return EDLIB_STATUS_ERROR;
-    }
-
-    // Build alignment by concatenating upper left alignment with lower right alignment.
-    *alignmentLength = ulAlignmentLength + lrAlignmentLength;
-    *alignment = static_cast<unsigned char*>(malloc((*alignmentLength) * sizeof(unsigned char)));
-    memcpy(*alignment, ulAlignment, ulAlignmentLength);
-    memcpy(*alignment + ulAlignmentLength, lrAlignment, lrAlignmentLength);
-
-    free(ulAlignment);
-    free(lrAlignment);
-    return EDLIB_STATUS_OK;
+  free(ulAlignment);
+  free(lrAlignment);
+  return EDLIB_STATUS_OK;
 }
 
-
 /**
- * Takes char query and char target, recognizes alphabet and transforms them into unsigned char sequences
- * where elements in sequences are not any more letters of alphabet, but their index in alphabet.
- * Most of internal edlib functions expect such transformed sequences.
- * This function will allocate queryTransformed and targetTransformed, so make sure to free them when done.
+ * Takes char query and char target, recognizes alphabet and transforms them
+ * into unsigned char sequences where elements in sequences are not any more
+ * letters of alphabet, but their index in alphabet. Most of internal edlib
+ * functions expect such transformed sequences. This function will allocate
+ * queryTransformed and targetTransformed, so make sure to free them when done.
  * Example:
  *   Original sequences: "ACT" and "CGT".
  *   Alphabet would be recognized as "ACTG". Alphabet length = 4.
@@ -1412,71 +1559,82 @@ static int obtainAlignmentHirschberg(
  * @param [in] queryLength
  * @param [in] targetOriginal
  * @param [in] targetLength
- * @param [out] queryTransformed  It will contain values in range [0, alphabet length - 1].
- * @param [out] targetTransformed  It will contain values in range [0, alphabet length - 1].
- * @return  Alphabet as a string of unique characters, where index of each character is its value in transformed
- *          sequences.
+ * @param [out] queryTransformed  It will contain values in range [0, alphabet
+ * length - 1].
+ * @param [out] targetTransformed  It will contain values in range [0, alphabet
+ * length - 1].
+ * @return  Alphabet as a string of unique characters, where index of each
+ * character is its value in transformed sequences.
  */
-static string transformSequences(const char* const queryOriginal, const int queryLength,
-                                 const char* const targetOriginal, const int targetLength,
-                                 unsigned char** const queryTransformed,
-                                 unsigned char** const targetTransformed) {
-    // Alphabet is constructed from letters that are present in sequences.
-    // Each letter is assigned an ordinal number, starting from 0 up to alphabetLength - 1,
-    // and new query and target are created in which letters are replaced with their ordinal numbers.
-    // This query and target are used in all the calculations later.
-    *queryTransformed = static_cast<unsigned char *>(malloc(sizeof(unsigned char) * queryLength));
-    *targetTransformed = static_cast<unsigned char *>(malloc(sizeof(unsigned char) * targetLength));
+static string transformSequences(const char *const queryOriginal,
+                                 const int queryLength,
+                                 const char *const targetOriginal,
+                                 const int targetLength,
+                                 unsigned char **const queryTransformed,
+                                 unsigned char **const targetTransformed) {
+  // Alphabet is constructed from letters that are present in sequences.
+  // Each letter is assigned an ordinal number, starting from 0 up to
+  // alphabetLength - 1, and new query and target are created in which letters
+  // are replaced with their ordinal numbers. This query and target are used in
+  // all the calculations later.
+  *queryTransformed =
+      static_cast<unsigned char *>(malloc(sizeof(unsigned char) * queryLength));
+  *targetTransformed = static_cast<unsigned char *>(
+      malloc(sizeof(unsigned char) * targetLength));
 
-    string alphabet = "";
+  string alphabet = "";
 
-    // Alphabet information, it is constructed on fly while transforming sequences.
-    // letterIdx[c] is index of letter c in alphabet.
-    unsigned char letterIdx[MAX_UCHAR + 1];
-    bool inAlphabet[MAX_UCHAR + 1]; // inAlphabet[c] is true if c is in alphabet
-    for (int i = 0; i < MAX_UCHAR + 1; i++) inAlphabet[i] = false;
+  // Alphabet information, it is constructed on fly while transforming
+  // sequences. letterIdx[c] is index of letter c in alphabet.
+  unsigned char letterIdx[MAX_UCHAR + 1];
+  bool inAlphabet[MAX_UCHAR + 1]; // inAlphabet[c] is true if c is in alphabet
+  for (int i = 0; i < MAX_UCHAR + 1; i++)
+    inAlphabet[i] = false;
 
-    for (int i = 0; i < queryLength; i++) {
-        unsigned char c = static_cast<unsigned char>(queryOriginal[i]);
-        if (!inAlphabet[c]) {
-            inAlphabet[c] = true;
-            letterIdx[c] = static_cast<unsigned char>(alphabet.size());
-            alphabet += queryOriginal[i];
-        }
-        (*queryTransformed)[i] = letterIdx[c];
+  for (int i = 0; i < queryLength; i++) {
+    unsigned char c = static_cast<unsigned char>(queryOriginal[i]);
+    if (!inAlphabet[c]) {
+      inAlphabet[c] = true;
+      letterIdx[c] = static_cast<unsigned char>(alphabet.size());
+      alphabet += queryOriginal[i];
     }
-    for (int i = 0; i < targetLength; i++) {
-        unsigned char c = static_cast<unsigned char>(targetOriginal[i]);
-        if (!inAlphabet[c]) {
-            inAlphabet[c] = true;
-            letterIdx[c] = static_cast<unsigned char>(alphabet.size());
-            alphabet += targetOriginal[i];
-        }
-        (*targetTransformed)[i] = letterIdx[c];
+    (*queryTransformed)[i] = letterIdx[c];
+  }
+  for (int i = 0; i < targetLength; i++) {
+    unsigned char c = static_cast<unsigned char>(targetOriginal[i]);
+    if (!inAlphabet[c]) {
+      inAlphabet[c] = true;
+      letterIdx[c] = static_cast<unsigned char>(alphabet.size());
+      alphabet += targetOriginal[i];
     }
+    (*targetTransformed)[i] = letterIdx[c];
+  }
 
-    return alphabet;
+  return alphabet;
 }
 
-
-extern "C" EdlibAlignConfig edlibNewAlignConfig(int k, EdlibAlignMode mode, EdlibAlignTask task,
-                                                const EdlibEqualityPair* additionalEqualities,
-                                                int additionalEqualitiesLength) {
-    EdlibAlignConfig config;
-    config.k = k;
-    config.mode = mode;
-    config.task = task;
-    config.additionalEqualities = additionalEqualities;
-    config.additionalEqualitiesLength = additionalEqualitiesLength;
-    return config;
+extern "C" EdlibAlignConfig
+edlibNewAlignConfig(int k, EdlibAlignMode mode, EdlibAlignTask task,
+                    const EdlibEqualityPair *additionalEqualities,
+                    int additionalEqualitiesLength) {
+  EdlibAlignConfig config;
+  config.k = k;
+  config.mode = mode;
+  config.task = task;
+  config.additionalEqualities = additionalEqualities;
+  config.additionalEqualitiesLength = additionalEqualitiesLength;
+  return config;
 }
 
 extern "C" EdlibAlignConfig edlibDefaultAlignConfig(void) {
-    return edlibNewAlignConfig(-1, EDLIB_MODE_NW, EDLIB_TASK_DISTANCE, NULL, 0);
+  return edlibNewAlignConfig(-1, EDLIB_MODE_NW, EDLIB_TASK_DISTANCE, NULL, 0);
 }
 
 extern "C" void edlibFreeAlignResult(EdlibAlignResult result) {
-    if (result.endLocations) free(result.endLocations);
-    if (result.startLocations) free(result.startLocations);
-    if (result.alignment) free(result.alignment);
+  if (result.endLocations)
+    free(result.endLocations);
+  if (result.startLocations)
+    free(result.startLocations);
+  if (result.alignment)
+    free(result.alignment);
 }

--- a/textsearch/csrc/edlib.h
+++ b/textsearch/csrc/edlib.h
@@ -1,0 +1,277 @@
+#ifndef EDLIB_H
+#define EDLIB_H
+
+/**
+ * @file
+ * @author Martin Sosic
+ * @brief Main header file, containing all public functions and structures.
+ */
+
+// Define EDLIB_API macro to properly export symbols
+#ifdef EDLIB_SHARED
+#    ifdef _WIN32
+#        ifdef EDLIB_BUILD
+#            define EDLIB_API __declspec(dllexport)
+#        else
+#            define EDLIB_API __declspec(dllimport)
+#        endif
+#    else
+#        define EDLIB_API __attribute__ ((visibility ("default")))
+#    endif
+#else
+#    define EDLIB_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Status codes
+#define EDLIB_STATUS_OK 0
+#define EDLIB_STATUS_ERROR 1
+
+    /**
+     * Alignment methods - how should Edlib treat gaps before and after query?
+     */
+    typedef enum {
+        /**
+         * Global method. This is the standard method.
+         * Useful when you want to find out how similar is first sequence to second sequence.
+         */
+        EDLIB_MODE_NW,
+        /**
+         * Prefix method. Similar to global method, but with a small twist - gap at query end is not penalized.
+         * What that means is that deleting elements from the end of second sequence is "free"!
+         * For example, if we had "AACT" and "AACTGGC", edit distance would be 0, because removing "GGC" from the end
+         * of second sequence is "free" and does not count into total edit distance. This method is appropriate
+         * when you want to find out how well first sequence fits at the beginning of second sequence.
+         */
+        EDLIB_MODE_SHW,
+        /**
+         * Infix method. Similar as prefix method, but with one more twist - gaps at query end and start are
+         * not penalized. What that means is that deleting elements from the start and end of second sequence is "free"!
+         * For example, if we had ACT and CGACTGAC, edit distance would be 0, because removing CG from the start
+         * and GAC from the end of second sequence is "free" and does not count into total edit distance.
+         * This method is appropriate when you want to find out how well first sequence fits at any part of
+         * second sequence.
+         * For example, if your second sequence was a long text and your first sequence was a sentence from that text,
+         * but slightly scrambled, you could use this method to discover how scrambled it is and where it fits in
+         * that text. In bioinformatics, this method is appropriate for aligning read to a sequence.
+         */
+        EDLIB_MODE_HW
+    } EdlibAlignMode;
+
+    /**
+     * Alignment tasks - what do you want Edlib to do?
+     */
+    typedef enum {
+        EDLIB_TASK_DISTANCE,  //!< Find edit distance and end locations.
+        EDLIB_TASK_LOC,       //!< Find edit distance, end locations and start locations.
+        EDLIB_TASK_PATH       //!< Find edit distance, end locations and start locations and alignment path.
+    } EdlibAlignTask;
+
+    /**
+     * Describes cigar format.
+     * @see http://samtools.github.io/hts-specs/SAMv1.pdf
+     * @see http://drive5.com/usearch/manual/cigar.html
+     */
+    typedef enum {
+        EDLIB_CIGAR_STANDARD,  //!< Match: 'M', Insertion: 'I', Deletion: 'D', Mismatch: 'M'.
+        EDLIB_CIGAR_EXTENDED   //!< Match: '=', Insertion: 'I', Deletion: 'D', Mismatch: 'X'.
+    } EdlibCigarFormat;
+
+// Edit operations.
+#define EDLIB_EDOP_MATCH 0    //!< Match.
+#define EDLIB_EDOP_INSERT 1   //!< Insertion to target = deletion from query.
+#define EDLIB_EDOP_DELETE 2   //!< Deletion from target = insertion to query.
+#define EDLIB_EDOP_MISMATCH 3 //!< Mismatch.
+
+    /**
+     * @brief Defines two given characters as equal.
+     */
+    typedef struct {
+        char first;
+        char second;
+    } EdlibEqualityPair;
+
+    /**
+     * @brief Configuration object for edlibAlign() function.
+     */
+    typedef struct {
+        /**
+         * Set k to non-negative value to tell edlib that edit distance is not larger than k.
+         * Smaller k can significantly improve speed of computation.
+         * If edit distance is larger than k, edlib will set edit distance to -1.
+         * Set k to negative value and edlib will internally auto-adjust k until score is found.
+         */
+        int k;
+
+        /**
+         * Alignment method.
+         * EDLIB_MODE_NW: global (Needleman-Wunsch)
+         * EDLIB_MODE_SHW: prefix. Gap after query is not penalized.
+         * EDLIB_MODE_HW: infix. Gaps before and after query are not penalized.
+         */
+        EdlibAlignMode mode;
+
+        /**
+         * Alignment task - tells Edlib what to calculate. Less to calculate, faster it is.
+         * EDLIB_TASK_DISTANCE - find edit distance and end locations of optimal alignment paths in target.
+         * EDLIB_TASK_LOC - find edit distance and start and end locations of optimal alignment paths in target.
+         * EDLIB_TASK_PATH - find edit distance, alignment path (and start and end locations of it in target).
+         */
+        EdlibAlignTask task;
+
+        /**
+         * List of pairs of characters, where each pair defines two characters as equal.
+         * This way you can extend edlib's definition of equality (which is that each character is equal only
+         * to itself).
+         * This can be useful if you have some wildcard characters that should match multiple other characters,
+         * or e.g. if you want edlib to be case insensitive.
+         * Can be set to NULL if there are none.
+         */
+        const EdlibEqualityPair* additionalEqualities;
+
+        /**
+         * Number of additional equalities, which is non-negative number.
+         * 0 if there are none.
+         */
+        int additionalEqualitiesLength;
+    } EdlibAlignConfig;
+
+    /**
+     * Helper method for easy construction of configuration object.
+     * @return Configuration object filled with given parameters.
+     */
+    EDLIB_API EdlibAlignConfig edlibNewAlignConfig(
+        int k, EdlibAlignMode mode, EdlibAlignTask task,
+        const EdlibEqualityPair* additionalEqualities,
+        int additionalEqualitiesLength
+    );
+
+    /**
+     * @return Default configuration object, with following defaults:
+     *         k = -1, mode = EDLIB_MODE_NW, task = EDLIB_TASK_DISTANCE, no additional equalities.
+     */
+    EDLIB_API EdlibAlignConfig edlibDefaultAlignConfig(void);
+
+
+    /**
+     * Container for results of alignment done by edlibAlign() function.
+     */
+    typedef struct {
+        /**
+         * EDLIB_STATUS_OK or EDLIB_STATUS_ERROR. If error, all other fields will have undefined values.
+         */
+        int status;
+
+        /**
+         * -1 if k is non-negative and edit distance is larger than k.
+         */
+        int editDistance;
+
+        /**
+         * Array of zero-based positions in target where optimal alignment paths end.
+         * If gap after query is penalized, gap counts as part of query (NW), otherwise not.
+         * Set to NULL if edit distance is larger than k.
+         * If you do not free whole result object using edlibFreeAlignResult(), do not forget to use free().
+         */
+        int* endLocations;
+
+        /**
+         * Array of zero-based positions in target where optimal alignment paths start,
+         * they correspond to endLocations.
+         * If gap before query is penalized, gap counts as part of query (NW), otherwise not.
+         * Set to NULL if not calculated or if edit distance is larger than k.
+         * If you do not free whole result object using edlibFreeAlignResult(), do not forget to use free().
+         */
+        int* startLocations;
+
+        /**
+         * Number of end (and start) locations.
+         */
+        int numLocations;
+
+        /**
+         * Alignment is found for first pair of start and end locations.
+         * Set to NULL if not calculated.
+         * Alignment is sequence of numbers: 0, 1, 2, 3.
+         * 0 stands for match.
+         * 1 stands for insertion to target.
+         * 2 stands for insertion to query.
+         * 3 stands for mismatch.
+         * Alignment aligns query to target from begining of query till end of query.
+         * If gaps are not penalized, they are not in alignment.
+         * If you do not free whole result object using edlibFreeAlignResult(), do not forget to use free().
+         */
+        unsigned char* alignment;
+
+        /**
+         * Length of alignment.
+         */
+        int alignmentLength;
+
+        /**
+         * Number of different characters in query and target together.
+         */
+        int alphabetLength;
+    } EdlibAlignResult;
+
+    /**
+     * Frees memory in EdlibAlignResult that was allocated by edlib.
+     * If you do not use it, make sure to free needed members manually using free().
+     */
+    EDLIB_API void edlibFreeAlignResult(EdlibAlignResult result);
+
+
+    /**
+     * Aligns two sequences (query and target) using edit distance (levenshtein distance).
+     * Through config parameter, this function supports different alignment methods (global, prefix, infix),
+     * as well as different modes of search (tasks).
+     * It always returns edit distance and end locations of optimal alignment in target.
+     * It optionally returns start locations of optimal alignment in target and alignment path,
+     * if you choose appropriate tasks.
+     * @param [in] query  First sequence.
+     * @param [in] queryLength  Number of characters in first sequence.
+     * @param [in] target  Second sequence.
+     * @param [in] targetLength  Number of characters in second sequence.
+     * @param [in] config  Additional alignment parameters, like alignment method and wanted results.
+     * @return  Result of alignment, which can contain edit distance, start and end locations and alignment path.
+     *          Make sure to clean up the object using edlibFreeAlignResult() or by manually freeing needed members.
+     */
+    EDLIB_API EdlibAlignResult edlibAlign(
+        const char* query, int queryLength,
+        const char* target, int targetLength,
+        const EdlibAlignConfig config
+    );
+
+
+    /**
+     * Builds cigar string from given alignment sequence.
+     * @param [in] alignment  Alignment sequence.
+     *     0 stands for match.
+     *     1 stands for insertion to target.
+     *     2 stands for insertion to query.
+     *     3 stands for mismatch.
+     * @param [in] alignmentLength
+     * @param [in] cigarFormat  Cigar will be returned in specified format.
+     * @return Cigar string.
+     *     I stands for insertion.
+     *     D stands for deletion.
+     *     X stands for mismatch. (used only in extended format)
+     *     = stands for match. (used only in extended format)
+     *     M stands for (mis)match. (used only in standard format)
+     *     String is null terminated.
+     *     Needed memory is allocated and given pointer is set to it.
+     *     Do not forget to free it later using free()!
+     */
+    EDLIB_API char* edlibAlignmentToCigar(
+        const unsigned char* alignment, int alignmentLength,
+        EdlibCigarFormat cigarFormat
+    );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // EDLIB_H

--- a/textsearch/csrc/edlib.h
+++ b/textsearch/csrc/edlib.h
@@ -1,5 +1,8 @@
-#ifndef EDLIB_H
-#define EDLIB_H
+// Copy from
+// https://github.com/Martinsos/edlib/blob/master/edlib/include/edlib.h
+
+#ifndef TEXTSEARCH_CSRC_DLIB_H
+#define TEXTSEARCH_CSRC_DLIB_H
 
 /**
  * @file
@@ -9,17 +12,17 @@
 
 // Define EDLIB_API macro to properly export symbols
 #ifdef EDLIB_SHARED
-#    ifdef _WIN32
-#        ifdef EDLIB_BUILD
-#            define EDLIB_API __declspec(dllexport)
-#        else
-#            define EDLIB_API __declspec(dllimport)
-#        endif
-#    else
-#        define EDLIB_API __attribute__ ((visibility ("default")))
-#    endif
+#ifdef _WIN32
+#ifdef EDLIB_BUILD
+#define EDLIB_API __declspec(dllexport)
 #else
-#    define EDLIB_API
+#define EDLIB_API __declspec(dllimport)
+#endif
+#else
+#define EDLIB_API __attribute__((visibility("default")))
+#endif
+#else
+#define EDLIB_API
 #endif
 
 #ifdef __cplusplus
@@ -30,55 +33,64 @@ extern "C" {
 #define EDLIB_STATUS_OK 0
 #define EDLIB_STATUS_ERROR 1
 
-    /**
-     * Alignment methods - how should Edlib treat gaps before and after query?
-     */
-    typedef enum {
-        /**
-         * Global method. This is the standard method.
-         * Useful when you want to find out how similar is first sequence to second sequence.
-         */
-        EDLIB_MODE_NW,
-        /**
-         * Prefix method. Similar to global method, but with a small twist - gap at query end is not penalized.
-         * What that means is that deleting elements from the end of second sequence is "free"!
-         * For example, if we had "AACT" and "AACTGGC", edit distance would be 0, because removing "GGC" from the end
-         * of second sequence is "free" and does not count into total edit distance. This method is appropriate
-         * when you want to find out how well first sequence fits at the beginning of second sequence.
-         */
-        EDLIB_MODE_SHW,
-        /**
-         * Infix method. Similar as prefix method, but with one more twist - gaps at query end and start are
-         * not penalized. What that means is that deleting elements from the start and end of second sequence is "free"!
-         * For example, if we had ACT and CGACTGAC, edit distance would be 0, because removing CG from the start
-         * and GAC from the end of second sequence is "free" and does not count into total edit distance.
-         * This method is appropriate when you want to find out how well first sequence fits at any part of
-         * second sequence.
-         * For example, if your second sequence was a long text and your first sequence was a sentence from that text,
-         * but slightly scrambled, you could use this method to discover how scrambled it is and where it fits in
-         * that text. In bioinformatics, this method is appropriate for aligning read to a sequence.
-         */
-        EDLIB_MODE_HW
-    } EdlibAlignMode;
+/**
+ * Alignment methods - how should Edlib treat gaps before and after query?
+ */
+typedef enum {
+  /**
+   * Global method. This is the standard method.
+   * Useful when you want to find out how similar is first sequence to second
+   * sequence.
+   */
+  EDLIB_MODE_NW,
+  /**
+   * Prefix method. Similar to global method, but with a small twist - gap at
+   * query end is not penalized. What that means is that deleting elements from
+   * the end of second sequence is "free"! For example, if we had "AACT" and
+   * "AACTGGC", edit distance would be 0, because removing "GGC" from the end of
+   * second sequence is "free" and does not count into total edit distance. This
+   * method is appropriate when you want to find out how well first sequence
+   * fits at the beginning of second sequence.
+   */
+  EDLIB_MODE_SHW,
+  /**
+   * Infix method. Similar as prefix method, but with one more twist - gaps at
+   * query end and start are not penalized. What that means is that deleting
+   * elements from the start and end of second sequence is "free"! For example,
+   * if we had ACT and CGACTGAC, edit distance would be 0, because removing CG
+   * from the start and GAC from the end of second sequence is "free" and does
+   * not count into total edit distance. This method is appropriate when you
+   * want to find out how well first sequence fits at any part of second
+   * sequence. For example, if your second sequence was a long text and your
+   * first sequence was a sentence from that text, but slightly scrambled, you
+   * could use this method to discover how scrambled it is and where it fits in
+   * that text. In bioinformatics, this method is appropriate for aligning read
+   * to a sequence.
+   */
+  EDLIB_MODE_HW
+} EdlibAlignMode;
 
-    /**
-     * Alignment tasks - what do you want Edlib to do?
-     */
-    typedef enum {
-        EDLIB_TASK_DISTANCE,  //!< Find edit distance and end locations.
-        EDLIB_TASK_LOC,       //!< Find edit distance, end locations and start locations.
-        EDLIB_TASK_PATH       //!< Find edit distance, end locations and start locations and alignment path.
-    } EdlibAlignTask;
+/**
+ * Alignment tasks - what do you want Edlib to do?
+ */
+typedef enum {
+  EDLIB_TASK_DISTANCE, //!< Find edit distance and end locations.
+  EDLIB_TASK_LOC, //!< Find edit distance, end locations and start locations.
+  EDLIB_TASK_PATH //!< Find edit distance, end locations and start locations and
+                  //!< alignment path.
+} EdlibAlignTask;
 
-    /**
-     * Describes cigar format.
-     * @see http://samtools.github.io/hts-specs/SAMv1.pdf
-     * @see http://drive5.com/usearch/manual/cigar.html
-     */
-    typedef enum {
-        EDLIB_CIGAR_STANDARD,  //!< Match: 'M', Insertion: 'I', Deletion: 'D', Mismatch: 'M'.
-        EDLIB_CIGAR_EXTENDED   //!< Match: '=', Insertion: 'I', Deletion: 'D', Mismatch: 'X'.
-    } EdlibCigarFormat;
+/**
+ * Describes cigar format.
+ * @see http://samtools.github.io/hts-specs/SAMv1.pdf
+ * @see http://drive5.com/usearch/manual/cigar.html
+ */
+typedef enum {
+  EDLIB_CIGAR_STANDARD, //!< Match: 'M', Insertion: 'I', Deletion: 'D',
+                        //!< Mismatch: 'M'.
+  EDLIB_CIGAR_EXTENDED //!< Match: '=', Insertion: 'I', Deletion: 'D', Mismatch:
+                       //!< 'X'.
+} EdlibCigarFormat;
 
 // Edit operations.
 #define EDLIB_EDOP_MATCH 0    //!< Match.
@@ -86,192 +98,194 @@ extern "C" {
 #define EDLIB_EDOP_DELETE 2   //!< Deletion from target = insertion to query.
 #define EDLIB_EDOP_MISMATCH 3 //!< Mismatch.
 
-    /**
-     * @brief Defines two given characters as equal.
-     */
-    typedef struct {
-        char first;
-        char second;
-    } EdlibEqualityPair;
+/**
+ * @brief Defines two given characters as equal.
+ */
+typedef struct {
+  char first;
+  char second;
+} EdlibEqualityPair;
 
-    /**
-     * @brief Configuration object for edlibAlign() function.
-     */
-    typedef struct {
-        /**
-         * Set k to non-negative value to tell edlib that edit distance is not larger than k.
-         * Smaller k can significantly improve speed of computation.
-         * If edit distance is larger than k, edlib will set edit distance to -1.
-         * Set k to negative value and edlib will internally auto-adjust k until score is found.
-         */
-        int k;
+/**
+ * @brief Configuration object for edlibAlign() function.
+ */
+typedef struct {
+  /**
+   * Set k to non-negative value to tell edlib that edit distance is not larger
+   * than k. Smaller k can significantly improve speed of computation. If edit
+   * distance is larger than k, edlib will set edit distance to -1. Set k to
+   * negative value and edlib will internally auto-adjust k until score is
+   * found.
+   */
+  int k;
 
-        /**
-         * Alignment method.
-         * EDLIB_MODE_NW: global (Needleman-Wunsch)
-         * EDLIB_MODE_SHW: prefix. Gap after query is not penalized.
-         * EDLIB_MODE_HW: infix. Gaps before and after query are not penalized.
-         */
-        EdlibAlignMode mode;
+  /**
+   * Alignment method.
+   * EDLIB_MODE_NW: global (Needleman-Wunsch)
+   * EDLIB_MODE_SHW: prefix. Gap after query is not penalized.
+   * EDLIB_MODE_HW: infix. Gaps before and after query are not penalized.
+   */
+  EdlibAlignMode mode;
 
-        /**
-         * Alignment task - tells Edlib what to calculate. Less to calculate, faster it is.
-         * EDLIB_TASK_DISTANCE - find edit distance and end locations of optimal alignment paths in target.
-         * EDLIB_TASK_LOC - find edit distance and start and end locations of optimal alignment paths in target.
-         * EDLIB_TASK_PATH - find edit distance, alignment path (and start and end locations of it in target).
-         */
-        EdlibAlignTask task;
+  /**
+   * Alignment task - tells Edlib what to calculate. Less to calculate, faster
+   * it is. EDLIB_TASK_DISTANCE - find edit distance and end locations of
+   * optimal alignment paths in target. EDLIB_TASK_LOC - find edit distance and
+   * start and end locations of optimal alignment paths in target.
+   * EDLIB_TASK_PATH - find edit distance, alignment path (and start and end
+   * locations of it in target).
+   */
+  EdlibAlignTask task;
 
-        /**
-         * List of pairs of characters, where each pair defines two characters as equal.
-         * This way you can extend edlib's definition of equality (which is that each character is equal only
-         * to itself).
-         * This can be useful if you have some wildcard characters that should match multiple other characters,
-         * or e.g. if you want edlib to be case insensitive.
-         * Can be set to NULL if there are none.
-         */
-        const EdlibEqualityPair* additionalEqualities;
+  /**
+   * List of pairs of characters, where each pair defines two characters as
+   * equal. This way you can extend edlib's definition of equality (which is
+   * that each character is equal only to itself). This can be useful if you
+   * have some wildcard characters that should match multiple other characters,
+   * or e.g. if you want edlib to be case insensitive.
+   * Can be set to NULL if there are none.
+   */
+  const EdlibEqualityPair *additionalEqualities;
 
-        /**
-         * Number of additional equalities, which is non-negative number.
-         * 0 if there are none.
-         */
-        int additionalEqualitiesLength;
-    } EdlibAlignConfig;
+  /**
+   * Number of additional equalities, which is non-negative number.
+   * 0 if there are none.
+   */
+  int additionalEqualitiesLength;
+} EdlibAlignConfig;
 
-    /**
-     * Helper method for easy construction of configuration object.
-     * @return Configuration object filled with given parameters.
-     */
-    EDLIB_API EdlibAlignConfig edlibNewAlignConfig(
-        int k, EdlibAlignMode mode, EdlibAlignTask task,
-        const EdlibEqualityPair* additionalEqualities,
-        int additionalEqualitiesLength
-    );
+/**
+ * Helper method for easy construction of configuration object.
+ * @return Configuration object filled with given parameters.
+ */
+EDLIB_API EdlibAlignConfig
+edlibNewAlignConfig(int k, EdlibAlignMode mode, EdlibAlignTask task,
+                    const EdlibEqualityPair *additionalEqualities,
+                    int additionalEqualitiesLength);
 
-    /**
-     * @return Default configuration object, with following defaults:
-     *         k = -1, mode = EDLIB_MODE_NW, task = EDLIB_TASK_DISTANCE, no additional equalities.
-     */
-    EDLIB_API EdlibAlignConfig edlibDefaultAlignConfig(void);
+/**
+ * @return Default configuration object, with following defaults:
+ *         k = -1, mode = EDLIB_MODE_NW, task = EDLIB_TASK_DISTANCE, no
+ * additional equalities.
+ */
+EDLIB_API EdlibAlignConfig edlibDefaultAlignConfig(void);
 
+/**
+ * Container for results of alignment done by edlibAlign() function.
+ */
+typedef struct {
+  /**
+   * EDLIB_STATUS_OK or EDLIB_STATUS_ERROR. If error, all other fields will have
+   * undefined values.
+   */
+  int status;
 
-    /**
-     * Container for results of alignment done by edlibAlign() function.
-     */
-    typedef struct {
-        /**
-         * EDLIB_STATUS_OK or EDLIB_STATUS_ERROR. If error, all other fields will have undefined values.
-         */
-        int status;
+  /**
+   * -1 if k is non-negative and edit distance is larger than k.
+   */
+  int editDistance;
 
-        /**
-         * -1 if k is non-negative and edit distance is larger than k.
-         */
-        int editDistance;
+  /**
+   * Array of zero-based positions in target where optimal alignment paths end.
+   * If gap after query is penalized, gap counts as part of query (NW),
+   * otherwise not. Set to NULL if edit distance is larger than k. If you do not
+   * free whole result object using edlibFreeAlignResult(), do not forget to use
+   * free().
+   */
+  int *endLocations;
 
-        /**
-         * Array of zero-based positions in target where optimal alignment paths end.
-         * If gap after query is penalized, gap counts as part of query (NW), otherwise not.
-         * Set to NULL if edit distance is larger than k.
-         * If you do not free whole result object using edlibFreeAlignResult(), do not forget to use free().
-         */
-        int* endLocations;
+  /**
+   * Array of zero-based positions in target where optimal alignment paths
+   * start, they correspond to endLocations. If gap before query is penalized,
+   * gap counts as part of query (NW), otherwise not. Set to NULL if not
+   * calculated or if edit distance is larger than k. If you do not free whole
+   * result object using edlibFreeAlignResult(), do not forget to use free().
+   */
+  int *startLocations;
 
-        /**
-         * Array of zero-based positions in target where optimal alignment paths start,
-         * they correspond to endLocations.
-         * If gap before query is penalized, gap counts as part of query (NW), otherwise not.
-         * Set to NULL if not calculated or if edit distance is larger than k.
-         * If you do not free whole result object using edlibFreeAlignResult(), do not forget to use free().
-         */
-        int* startLocations;
+  /**
+   * Number of end (and start) locations.
+   */
+  int numLocations;
 
-        /**
-         * Number of end (and start) locations.
-         */
-        int numLocations;
+  /**
+   * Alignment is found for first pair of start and end locations.
+   * Set to NULL if not calculated.
+   * Alignment is sequence of numbers: 0, 1, 2, 3.
+   * 0 stands for match.
+   * 1 stands for insertion to target.
+   * 2 stands for insertion to query.
+   * 3 stands for mismatch.
+   * Alignment aligns query to target from begining of query till end of query.
+   * If gaps are not penalized, they are not in alignment.
+   * If you do not free whole result object using edlibFreeAlignResult(), do not
+   * forget to use free().
+   */
+  unsigned char *alignment;
 
-        /**
-         * Alignment is found for first pair of start and end locations.
-         * Set to NULL if not calculated.
-         * Alignment is sequence of numbers: 0, 1, 2, 3.
-         * 0 stands for match.
-         * 1 stands for insertion to target.
-         * 2 stands for insertion to query.
-         * 3 stands for mismatch.
-         * Alignment aligns query to target from begining of query till end of query.
-         * If gaps are not penalized, they are not in alignment.
-         * If you do not free whole result object using edlibFreeAlignResult(), do not forget to use free().
-         */
-        unsigned char* alignment;
+  /**
+   * Length of alignment.
+   */
+  int alignmentLength;
 
-        /**
-         * Length of alignment.
-         */
-        int alignmentLength;
+  /**
+   * Number of different characters in query and target together.
+   */
+  int alphabetLength;
+} EdlibAlignResult;
 
-        /**
-         * Number of different characters in query and target together.
-         */
-        int alphabetLength;
-    } EdlibAlignResult;
+/**
+ * Frees memory in EdlibAlignResult that was allocated by edlib.
+ * If you do not use it, make sure to free needed members manually using free().
+ */
+EDLIB_API void edlibFreeAlignResult(EdlibAlignResult result);
 
-    /**
-     * Frees memory in EdlibAlignResult that was allocated by edlib.
-     * If you do not use it, make sure to free needed members manually using free().
-     */
-    EDLIB_API void edlibFreeAlignResult(EdlibAlignResult result);
+/**
+ * Aligns two sequences (query and target) using edit distance (levenshtein
+ * distance). Through config parameter, this function supports different
+ * alignment methods (global, prefix, infix), as well as different modes of
+ * search (tasks). It always returns edit distance and end locations of optimal
+ * alignment in target. It optionally returns start locations of optimal
+ * alignment in target and alignment path, if you choose appropriate tasks.
+ * @param [in] query  First sequence.
+ * @param [in] queryLength  Number of characters in first sequence.
+ * @param [in] target  Second sequence.
+ * @param [in] targetLength  Number of characters in second sequence.
+ * @param [in] config  Additional alignment parameters, like alignment method
+ * and wanted results.
+ * @return  Result of alignment, which can contain edit distance, start and end
+ * locations and alignment path. Make sure to clean up the object using
+ * edlibFreeAlignResult() or by manually freeing needed members.
+ */
+EDLIB_API EdlibAlignResult edlibAlign(const char *query, int queryLength,
+                                      const char *target, int targetLength,
+                                      const EdlibAlignConfig config);
 
-
-    /**
-     * Aligns two sequences (query and target) using edit distance (levenshtein distance).
-     * Through config parameter, this function supports different alignment methods (global, prefix, infix),
-     * as well as different modes of search (tasks).
-     * It always returns edit distance and end locations of optimal alignment in target.
-     * It optionally returns start locations of optimal alignment in target and alignment path,
-     * if you choose appropriate tasks.
-     * @param [in] query  First sequence.
-     * @param [in] queryLength  Number of characters in first sequence.
-     * @param [in] target  Second sequence.
-     * @param [in] targetLength  Number of characters in second sequence.
-     * @param [in] config  Additional alignment parameters, like alignment method and wanted results.
-     * @return  Result of alignment, which can contain edit distance, start and end locations and alignment path.
-     *          Make sure to clean up the object using edlibFreeAlignResult() or by manually freeing needed members.
-     */
-    EDLIB_API EdlibAlignResult edlibAlign(
-        const char* query, int queryLength,
-        const char* target, int targetLength,
-        const EdlibAlignConfig config
-    );
-
-
-    /**
-     * Builds cigar string from given alignment sequence.
-     * @param [in] alignment  Alignment sequence.
-     *     0 stands for match.
-     *     1 stands for insertion to target.
-     *     2 stands for insertion to query.
-     *     3 stands for mismatch.
-     * @param [in] alignmentLength
-     * @param [in] cigarFormat  Cigar will be returned in specified format.
-     * @return Cigar string.
-     *     I stands for insertion.
-     *     D stands for deletion.
-     *     X stands for mismatch. (used only in extended format)
-     *     = stands for match. (used only in extended format)
-     *     M stands for (mis)match. (used only in standard format)
-     *     String is null terminated.
-     *     Needed memory is allocated and given pointer is set to it.
-     *     Do not forget to free it later using free()!
-     */
-    EDLIB_API char* edlibAlignmentToCigar(
-        const unsigned char* alignment, int alignmentLength,
-        EdlibCigarFormat cigarFormat
-    );
+/**
+ * Builds cigar string from given alignment sequence.
+ * @param [in] alignment  Alignment sequence.
+ *     0 stands for match.
+ *     1 stands for insertion to target.
+ *     2 stands for insertion to query.
+ *     3 stands for mismatch.
+ * @param [in] alignmentLength
+ * @param [in] cigarFormat  Cigar will be returned in specified format.
+ * @return Cigar string.
+ *     I stands for insertion.
+ *     D stands for deletion.
+ *     X stands for mismatch. (used only in extended format)
+ *     = stands for match. (used only in extended format)
+ *     M stands for (mis)match. (used only in standard format)
+ *     String is null terminated.
+ *     Needed memory is allocated and given pointer is set to it.
+ *     Do not forget to free it later using free()!
+ */
+EDLIB_API char *edlibAlignmentToCigar(const unsigned char *alignment,
+                                      int alignmentLength,
+                                      EdlibCigarFormat cigarFormat);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // EDLIB_H
+#endif // TEXTSEARCH_CSRC_DLIB_H

--- a/textsearch/csrc/edlib_inl.h
+++ b/textsearch/csrc/edlib_inl.h
@@ -1,22 +1,61 @@
-// Copy from
+// Copied from
 // https://github.com/Martinsos/edlib/blob/master/edlib/src/edlib.cpp
-//
-#include "textsearch/csrc/edlib.h"
 
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TEXTSEARCH_CSRC_DLIB_INL_H_
+#define TEXTSEARCH_CSRC_DLIB_INL_H_
+
+#ifndef IS_IN_TEXTSEARCH_CSRC_EDLIB_H_
+#error "this file is supposed to be included only by edlib.h"
+#endif
+
+#include "textsearch/csrc/pair_hash.h"
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <stdint.h>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
-using namespace std;
+namespace edlib {
+template <class T>
+using SetOfPairs = std::unordered_set<std::pair<T, T>, pair_hash<T, T>>;
+
+class AlphabetTooBigException : public std::exception {
+public:
+  const char *what() const noexcept override {
+    return "Alphabet is larger than the type you are using for it. "
+           "Larger type for AlphabetIdx should be used.";
+  }
+};
+
+namespace internal {
 
 typedef uint64_t Word;
-static const int WORD_SIZE = sizeof(Word) * 8; // Size of Word in bits
-static const Word WORD_1 = static_cast<Word>(1);
-static const Word HIGH_BIT_MASK = WORD_1 << (WORD_SIZE - 1); // 100..00
-static const int MAX_UCHAR = 255;
+const int WORD_SIZE = sizeof(Word) * 8; // Size of Word in bits
+const Word WORD_1 = static_cast<Word>(1);
+const Word HIGH_BIT_MASK = WORD_1 << (WORD_SIZE - 1); // 100..00
 
 // Data needed to find alignment.
 struct AlignmentData {
@@ -52,103 +91,120 @@ struct Block {
   int score; // score of last cell in block;
 
   Block() {}
+
   Block(Word p, Word m, int s) : P(p), M(m), score(s) {}
 };
 
 /**
- * Defines equality relation on alphabet characters.
- * By default each character is always equal only to itself, but you can also
- * provide additional equalities.
+ * Defines equality relation on indexes of alphabet elements.
+ * By default each alphabet index is always equal only to itself, but you can
+ * also provide additional equalities.
  */
-class EqualityDefinition {
+template <class AlphabetIdx> class EqualityDefinition {
 private:
-  bool matrix[MAX_UCHAR + 1][MAX_UCHAR + 1];
+  SetOfPairs<AlphabetIdx> equalitySet;
+  // The boolean array, hasAdditionalEqualities shows which alphabet indexes
+  // have at least one additional equality.
+  std::vector<bool> hasAdditionalEqualities;
 
 public:
-  EqualityDefinition(const string &alphabet,
-                     const EdlibEqualityPair *additionalEqualities = NULL,
-                     const int additionalEqualitiesLength = 0) {
-    for (int i = 0; i < static_cast<int>(alphabet.size()); i++) {
-      for (int j = 0; j < static_cast<int>(alphabet.size()); j++) {
-        matrix[i][j] = (i == j);
-      }
-    }
-    if (additionalEqualities != NULL) {
-      for (int i = 0; i < additionalEqualitiesLength; i++) {
-        size_t firstTransformed = alphabet.find(additionalEqualities[i].first);
-        size_t secondTransformed =
-            alphabet.find(additionalEqualities[i].second);
-        if (firstTransformed != string::npos &&
-            secondTransformed != string::npos) {
-          matrix[firstTransformed][secondTransformed] =
-              matrix[secondTransformed][firstTransformed] = true;
-        }
-      }
+  EqualityDefinition(
+      const std::vector<EdlibEqualityPair<AlphabetIdx>> &additionalEqualities,
+      AlphabetIdx alphabetSize) {
+    hasAdditionalEqualities.resize(alphabetSize);
+    std::fill(hasAdditionalEqualities.begin(), hasAdditionalEqualities.end(),
+              false);
+    for (size_t i = 0; i < additionalEqualities.size(); i++) {
+      AlphabetIdx a = additionalEqualities.at(i).first;
+      AlphabetIdx b = additionalEqualities.at(i).second;
+      equalitySet.insert(std::pair<AlphabetIdx, AlphabetIdx>(a, b));
+      equalitySet.insert(std::pair<AlphabetIdx, AlphabetIdx>(b, a));
+      hasAdditionalEqualities[a] = true;
+      hasAdditionalEqualities[b] = true;
     }
   }
-
-  /**
-   * @param a  Element from transformed sequence.
-   * @param b  Element from transformed sequence.
+  /*
+   * @param a  an alphabet index from transformed sequence.
+   * @param b  an alphabet index from transformed sequence.
    * @return True if a and b are defined as equal, false otherwise.
    */
-  bool areEqual(unsigned char a, unsigned char b) const { return matrix[a][b]; }
+  bool areEqual(AlphabetIdx a, AlphabetIdx b) const {
+    return (a == b) ||
+           (hasAdditionalEqualities[a] && hasAdditionalEqualities[b] &&
+            equalitySet.count(std::pair<AlphabetIdx, AlphabetIdx>(a, b)));
+  }
 };
 
-static int myersCalcEditDistanceSemiGlobal(
-    const Word *Peq, int W, int maxNumBlocks, int queryLength,
-    const unsigned char *target, int targetLength, int k, EdlibAlignMode mode,
-    int *bestScore_, int **positions_, int *numPositions_);
+template <class AlphabetIdx>
+int myersCalcEditDistanceSemiGlobal(const Word *Peq, int W, int maxNumBlocks,
+                                    int queryLength, const AlphabetIdx *target,
+                                    int targetLength, int k,
+                                    EdlibAlignMode mode, int *bestScore_,
+                                    int **positions_, int *numPositions_);
 
-static int myersCalcEditDistanceNW(const Word *Peq, int W, int maxNumBlocks,
-                                   int queryLength, const unsigned char *target,
-                                   int targetLength, int k, int *bestScore_,
-                                   int *position_, bool findAlignment,
-                                   AlignmentData **alignData,
-                                   int targetStopPosition);
+template <class AlphabetIdx>
+int myersCalcEditDistanceNW(const Word *Peq, int W, int maxNumBlocks,
+                            int queryLength, const AlphabetIdx *target,
+                            int targetLength, int k, int *bestScore_,
+                            int *position_, bool findAlignment,
+                            AlignmentData **alignData, int targetStopPosition);
 
-static int obtainAlignment(const unsigned char *query,
-                           const unsigned char *rQuery, int queryLength,
-                           const unsigned char *target,
-                           const unsigned char *rTarget, int targetLength,
-                           const EqualityDefinition &equalityDefinition,
-                           int alphabetLength, int bestScore,
-                           unsigned char **alignment, int *alignmentLength);
+template <class AlphabetIdx>
+int obtainAlignment(const AlphabetIdx *query, const AlphabetIdx *rQuery,
+                    int queryLength, const AlphabetIdx *target,
+                    const AlphabetIdx *rTarget, int targetLength,
+                    const EqualityDefinition<AlphabetIdx> &equalityDefinition,
+                    int alphabetLength, int bestScore,
+                    unsigned char **alignment, int *alignmentLength);
 
-static int obtainAlignmentHirschberg(
-    const unsigned char *query, const unsigned char *rQuery, int queryLength,
-    const unsigned char *target, const unsigned char *rTarget, int targetLength,
-    const EqualityDefinition &equalityDefinition, int alphabetLength,
-    int bestScore, unsigned char **alignment, int *alignmentLength);
+template <class AlphabetIdx>
+int obtainAlignmentHirschberg(
+    const AlphabetIdx *query, const AlphabetIdx *rQuery, int queryLength,
+    const AlphabetIdx *target, const AlphabetIdx *rTarget, int targetLength,
+    const EqualityDefinition<AlphabetIdx> &equalityDefinition,
+    int alphabetLength, int bestScore, unsigned char **alignment,
+    int *alignmentLength);
 
-static int obtainAlignmentTraceback(int queryLength, int targetLength,
+inline int obtainAlignmentTraceback(int queryLength, int targetLength,
                                     int bestScore,
                                     const AlignmentData *alignData,
                                     unsigned char **alignment,
                                     int *alignmentLength);
 
-static string transformSequences(const char *queryOriginal, int queryLength,
-                                 const char *targetOriginal, int targetLength,
-                                 unsigned char **queryTransformed,
-                                 unsigned char **targetTransformed);
+template <class Element, class AlphabetIdx>
+std::unordered_map<Element, AlphabetIdx>
+transformSequences(const Element *queryOriginal, int queryLength,
+                   const Element *targetOriginal, int targetLength,
+                   AlphabetIdx **queryTransformed,
+                   AlphabetIdx **targetTransformed);
 
-static inline int ceilDiv(int x, int y);
+template <class Element, class AlphabetIdx>
+std::vector<EdlibEqualityPair<AlphabetIdx>> transformEqualityPairs(
+    const EdlibEqualityPair<Element> *additionalEqualities,
+    int additionalEqualitiesLength,
+    const std::unordered_map<Element, AlphabetIdx> &elementToAlphabetIdx);
 
-static inline unsigned char *createReverseCopy(const unsigned char *seq,
-                                               int length);
+inline int ceilDiv(int x, int y);
 
-static inline Word *buildPeq(const int alphabetLength,
-                             const unsigned char *query, const int queryLength,
-                             const EqualityDefinition &equalityDefinition);
+template <class E> inline E *createReverseCopy(const E *seq, int length);
+
+template <class AlphabetIdx>
+inline Word *
+buildPeq(const AlphabetIdx alphabetLength, const AlphabetIdx *query,
+         const int queryLength,
+         const EqualityDefinition<AlphabetIdx> &equalityDefinition);
+} // namespace internal
 
 /**
  * Main edlib method.
  */
-extern "C" EdlibAlignResult edlibAlign(const char *const queryOriginal,
-                                       const int queryLength,
-                                       const char *const targetOriginal,
-                                       const int targetLength,
-                                       const EdlibAlignConfig config) {
+template <class Element, class AlphabetIdx>
+EdlibAlignResult
+edlibAlign(const Element *const queryOriginal, const int queryLength,
+           const Element *const targetOriginal, const int targetLength,
+           const EdlibAlignConfig<Element> config) {
+  using namespace internal;
+
   EdlibAlignResult result;
   result.status = EDLIB_STATUS_OK;
   result.editDistance = -1;
@@ -156,16 +212,13 @@ extern "C" EdlibAlignResult edlibAlign(const char *const queryOriginal,
   result.numLocations = 0;
   result.alignment = NULL;
   result.alignmentLength = 0;
-  result.alphabetLength = 0;
 
   /*------------ TRANSFORM SEQUENCES AND RECOGNIZE ALPHABET -----------*/
-  unsigned char *query, *target;
-  string alphabet =
-      transformSequences(queryOriginal, queryLength, targetOriginal,
-                         targetLength, &query, &target);
-  result.alphabetLength = static_cast<int>(alphabet.size());
-  /*-------------------------------------------------------*/
-
+  AlphabetIdx *query, *target;
+  std::unordered_map<Element, AlphabetIdx> elementToAlphabetIdx =
+      transformSequences<Element, AlphabetIdx>(queryOriginal, queryLength,
+                                               targetOriginal, targetLength,
+                                               &query, &target);
   // Handle special situation when at least one of the sequences has length 0.
   if (queryLength == 0 || targetLength == 0) {
     if (config.mode == EDLIB_MODE_NW) {
@@ -191,12 +244,16 @@ extern "C" EdlibAlignResult edlibAlign(const char *const queryOriginal,
   int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE); // bmax in Myers
   int W = maxNumBlocks * WORD_SIZE -
           queryLength; // number of redundant cells in last level blocks
-  EqualityDefinition equalityDefinition(alphabet, config.additionalEqualities,
-                                        config.additionalEqualitiesLength);
-  Word *Peq = buildPeq(static_cast<int>(alphabet.size()), query, queryLength,
-                       equalityDefinition);
+  std::vector<EdlibEqualityPair<AlphabetIdx>> additionalEqualities =
+      transformEqualityPairs(config.additionalEqualities,
+                             config.additionalEqualitiesLength,
+                             elementToAlphabetIdx);
+  EqualityDefinition<AlphabetIdx> equalityDefinition(
+      additionalEqualities, elementToAlphabetIdx.size());
+  Word *Peq = buildPeq<AlphabetIdx>(
+      static_cast<AlphabetIdx>(elementToAlphabetIdx.size()), query, queryLength,
+      equalityDefinition);
   /*-------------------------------------------------------*/
-
   /*------------------ MAIN CALCULATION -------------------*/
   // TODO: Store alignment data only after k is determined? That could make
   // things faster.
@@ -212,14 +269,14 @@ extern "C" EdlibAlignResult edlibAlign(const char *const queryOriginal,
 
   do {
     if (config.mode == EDLIB_MODE_HW || config.mode == EDLIB_MODE_SHW) {
-      myersCalcEditDistanceSemiGlobal(
+      myersCalcEditDistanceSemiGlobal<AlphabetIdx>(
           Peq, W, maxNumBlocks, queryLength, target, targetLength, k,
           config.mode, &(result.editDistance), &(result.endLocations),
           &(result.numLocations));
     } else { // mode == EDLIB_MODE_NW
-      myersCalcEditDistanceNW(Peq, W, maxNumBlocks, queryLength, target,
-                              targetLength, k, &(result.editDistance),
-                              &positionNW, false, &alignData, -1);
+      myersCalcEditDistanceNW<AlphabetIdx>(
+          Peq, W, maxNumBlocks, queryLength, target, targetLength, k,
+          &(result.editDistance), &positionNW, false, &alignData, -1);
     }
     k *= 2;
   } while (dynamicK && result.editDistance == -1);
@@ -238,11 +295,14 @@ extern "C" EdlibAlignResult edlibAlign(const char *const queryOriginal,
           static_cast<int *>(malloc(result.numLocations * sizeof(int)));
       if (config.mode ==
           EDLIB_MODE_HW) { // If HW, I need to calculate start locations.
-        const unsigned char *rTarget = createReverseCopy(target, targetLength);
-        const unsigned char *rQuery = createReverseCopy(query, queryLength);
+        const AlphabetIdx *rTarget =
+            createReverseCopy<AlphabetIdx>(target, targetLength);
+        const AlphabetIdx *rQuery =
+            createReverseCopy<AlphabetIdx>(query, queryLength);
         // Peq for reversed query.
-        Word *rPeq = buildPeq(static_cast<int>(alphabet.size()), rQuery,
-                              queryLength, equalityDefinition);
+        Word *rPeq = buildPeq<AlphabetIdx>(
+            static_cast<AlphabetIdx>(elementToAlphabetIdx.size()), rQuery,
+            queryLength, equalityDefinition);
         for (int i = 0; i < result.numLocations; i++) {
           int endLocation = result.endLocations[i];
           if (endLocation == -1) {
@@ -266,7 +326,7 @@ extern "C" EdlibAlignResult edlibAlign(const char *const queryOriginal,
           } else {
             int bestScoreSHW, numPositionsSHW;
             int *positionsSHW;
-            myersCalcEditDistanceSemiGlobal(
+            myersCalcEditDistanceSemiGlobal<AlphabetIdx>(
                 rPeq, W, maxNumBlocks, queryLength,
                 rTarget + targetLength - endLocation - 1, endLocation + 1,
                 result.editDistance, EDLIB_MODE_SHW, &bestScoreSHW,
@@ -293,15 +353,17 @@ extern "C" EdlibAlignResult edlibAlign(const char *const queryOriginal,
     if (config.task == EDLIB_TASK_PATH) {
       int alnStartLocation = result.startLocations[0];
       int alnEndLocation = result.endLocations[0];
-      const unsigned char *alnTarget = target + alnStartLocation;
+      const AlphabetIdx *alnTarget = target + alnStartLocation;
       const int alnTargetLength = alnEndLocation - alnStartLocation + 1;
-      const unsigned char *rAlnTarget =
-          createReverseCopy(alnTarget, alnTargetLength);
-      const unsigned char *rQuery = createReverseCopy(query, queryLength);
-      obtainAlignment(query, rQuery, queryLength, alnTarget, rAlnTarget,
-                      alnTargetLength, equalityDefinition,
-                      static_cast<int>(alphabet.size()), result.editDistance,
-                      &(result.alignment), &(result.alignmentLength));
+      const AlphabetIdx *rAlnTarget =
+          createReverseCopy<AlphabetIdx>(alnTarget, alnTargetLength);
+      const AlphabetIdx *rQuery =
+          createReverseCopy<AlphabetIdx>(query, queryLength);
+      obtainAlignment<AlphabetIdx>(
+          query, rQuery, queryLength, alnTarget, rAlnTarget, alnTargetLength,
+          equalityDefinition,
+          static_cast<AlphabetIdx>(elementToAlphabetIdx.size()),
+          result.editDistance, &(result.alignment), &(result.alignmentLength));
       delete[] rAlnTarget;
       delete[] rQuery;
     }
@@ -319,9 +381,9 @@ extern "C" EdlibAlignResult edlibAlign(const char *const queryOriginal,
   return result;
 }
 
-extern "C" char *edlibAlignmentToCigar(const unsigned char *const alignment,
-                                       const int alignmentLength,
-                                       const EdlibCigarFormat cigarFormat) {
+inline char *edlibAlignmentToCigar(const unsigned char *const alignment,
+                                   const int alignmentLength,
+                                   const EdlibCigarFormat cigarFormat) {
   if (cigarFormat != EDLIB_CIGAR_EXTENDED &&
       cigarFormat != EDLIB_CIGAR_STANDARD) {
     return 0;
@@ -334,7 +396,7 @@ extern "C" char *edlibAlignmentToCigar(const unsigned char *const alignment,
     moveCodeToChar[0] = moveCodeToChar[3] = 'M';
   }
 
-  vector<char> *cigar = new vector<char>();
+  std::vector<char> *cigar = new std::vector<char>();
   char lastMove = 0; // Char of last move. 0 if there was no previous move.
   int numOfSameMoves = 0;
   for (int i = 0; i <= alignmentLength; i++) {
@@ -373,6 +435,8 @@ extern "C" char *edlibAlignmentToCigar(const unsigned char *const alignment,
   return cigar_;
 }
 
+namespace internal {
+
 /**
  * Build Peq table for given query and alphabet.
  * Peq is table of dimensions alphabetLength+1 x maxNumBlocks.
@@ -380,10 +444,11 @@ extern "C" char *edlibAlignmentToCigar(const unsigned char *const alignment,
  * equals symbol s, otherwise it is 0. NOTICE: free returned array with
  * delete[]!
  */
-static inline Word *buildPeq(const int alphabetLength,
-                             const unsigned char *const query,
-                             const int queryLength,
-                             const EqualityDefinition &equalityDefinition) {
+template <class AlphabetIdx>
+inline Word *
+buildPeq(const AlphabetIdx alphabetLength, const AlphabetIdx *query,
+         const int queryLength,
+         const EqualityDefinition<AlphabetIdx> &equalityDefinition) {
   int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
   // table of dimensions alphabetLength+1 x maxNumBlocks. Last symbol is
   // wildcard.
@@ -391,7 +456,7 @@ static inline Word *buildPeq(const int alphabetLength,
 
   // Build Peq (1 is match, 0 is mismatch). NOTE: last column is wildcard(symbol
   // that matches anything) with just 1s
-  for (int symbol = 0; symbol <= alphabetLength; symbol++) {
+  for (AlphabetIdx symbol = 0; symbol <= alphabetLength; symbol++) {
     for (int b = 0; b < maxNumBlocks; b++) {
       if (symbol < alphabetLength) {
         Peq[symbol * maxNumBlocks + b] = 0;
@@ -415,15 +480,14 @@ static inline Word *buildPeq(const int alphabetLength,
  * Returns new sequence that is reverse of given sequence.
  * Free returned array with delete[].
  */
-static inline unsigned char *createReverseCopy(const unsigned char *const seq,
-                                               const int length) {
-  unsigned char *rSeq = new unsigned char[length];
+template <class E>
+inline E *createReverseCopy(const E *const seq, const int length) {
+  E *rSeq = new E[length];
   for (int i = 0; i < length; i++) {
     rSeq[i] = seq[length - i - 1];
   }
   return rSeq;
 }
-
 /**
  * Corresponds to Advance_Block function from Myers.
  * Calculates one word(block), which is part of a column.
@@ -439,8 +503,8 @@ static inline unsigned char *createReverseCopy(const unsigned char *const seq,
  * == 0.
  * @param [out] hout  Will be +1, 0 or -1.
  */
-static inline int calculateBlock(Word Pv, Word Mv, Word Eq, const int hin,
-                                 Word &PvOut, Word &MvOut) {
+inline int calculateBlock(Word Pv, Word Mv, Word Eq, const int hin, Word &PvOut,
+                          Word &MvOut) {
   // hin can be 1, -1 or 0.
   // 1  -> 00...01
   // 0  -> 00...00
@@ -483,20 +547,20 @@ static inline int calculateBlock(Word Pv, Word Mv, Word Eq, const int hin,
  * Does ceiling division x / y.
  * Note: x and y must be non-negative and x + y must not overflow.
  */
-static inline int ceilDiv(const int x, const int y) {
+inline int ceilDiv(const int x, const int y) {
   return x % y ? x / y + 1 : x / y;
 }
 
-static inline int min(const int x, const int y) { return x < y ? x : y; }
+inline int min(const int x, const int y) { return x < y ? x : y; }
 
-static inline int max(const int x, const int y) { return x > y ? x : y; }
+inline int max(const int x, const int y) { return x > y ? x : y; }
 
 /**
  * @param [in] block
  * @return Values of cells in block, starting with bottom cell in block.
  */
-static inline vector<int> getBlockCellValues(const Block block) {
-  vector<int> scores(WORD_SIZE);
+inline std::vector<int> getBlockCellValues(const Block block) {
+  std::vector<int> scores(WORD_SIZE);
   int score = block.score;
   Word mask = HIGH_BIT_MASK;
   for (int i = 0; i < WORD_SIZE - 1; i++) {
@@ -518,7 +582,7 @@ static inline vector<int> getBlockCellValues(const Block block) {
  * @param [out] dest  Array into which cell values are written. Must have size
  * of at least WORD_SIZE.
  */
-static inline void readBlock(const Block block, int *const dest) {
+inline void readBlock(const Block block, int *const dest) {
   int score = block.score;
   Word mask = HIGH_BIT_MASK;
   for (int i = 0; i < WORD_SIZE - 1; i++) {
@@ -539,7 +603,7 @@ static inline void readBlock(const Block block, int *const dest) {
  * @param [out] dest  Array into which cell values are written. Must have size
  * of at least WORD_SIZE.
  */
-static inline void readBlockReverse(const Block block, int *const dest) {
+inline void readBlockReverse(const Block block, int *const dest) {
   int score = block.score;
   Word mask = HIGH_BIT_MASK;
   for (int i = 0; i < WORD_SIZE - 1; i++) {
@@ -558,8 +622,8 @@ static inline void readBlockReverse(const Block block, int *const dest) {
  * @param [in] k
  * @return True if all cells in block have value larger than k, otherwise false.
  */
-static inline bool allBlockCellsLarger(const Block block, const int k) {
-  vector<int> scores = getBlockCellValues(block);
+inline bool allBlockCellsLarger(const Block block, const int k) {
+  std::vector<int> scores = getBlockCellValues(block);
   for (int i = 0; i < WORD_SIZE; i++) {
     if (scores[i] <= k)
       return false;
@@ -588,9 +652,11 @@ static inline bool allBlockCellsLarger(const Block block, const int k) {
  * @param [out] numPositions_  Number of positions in the positions_ array.
  * @return Status.
  */
-static int myersCalcEditDistanceSemiGlobal(
+
+template <class AlphabetIdx>
+int myersCalcEditDistanceSemiGlobal(
     const Word *const Peq, const int W, const int maxNumBlocks,
-    const int queryLength, const unsigned char *const target,
+    const int queryLength, const AlphabetIdx *const target,
     const int targetLength, int k, const EdlibAlignMode mode,
     int *const bestScore_, int **const positions_, int *const numPositions_) {
   *positions_ = NULL;
@@ -624,13 +690,13 @@ static int myersCalcEditDistanceSemiGlobal(
   }
 
   int bestScore = -1;
-  vector<int> positions; // TODO: Maybe put this on heap?
+  std::vector<int> positions; // TODO: Maybe put this on heap?
   const int startHout = mode == EDLIB_MODE_HW
                             ? 0
                             : 1; // If 0 then gap before query is not penalized;
-  const unsigned char *targetChar = target;
+  const AlphabetIdx *targetElement = target;
   for (int c = 0; c < targetLength; c++) { // for each column
-    const Word *Peq_c = Peq + (*targetChar) * maxNumBlocks;
+    const Word *Peq_c = Peq + (*targetElement) * maxNumBlocks;
 
     //----------------------- Calculate column -------------------------//
     int hout = startHout;
@@ -737,12 +803,12 @@ static int myersCalcEditDistanceSemiGlobal(
     }
     //------------------------------------------------------------------//
 
-    targetChar++;
+    targetElement++;
   }
 
   // Obtain results for last W columns from last column.
   if (lastBlock == maxNumBlocks - 1) {
-    vector<int> blockScores = getBlockCellValues(*bl);
+    std::vector<int> blockScores = getBlockCellValues(*bl);
     for (int i = 0; i < W; i++) {
       int colScore = blockScores[i + 1];
       if (colScore <= k && (bestScore == -1 || colScore <= bestScore)) {
@@ -795,12 +861,15 @@ static int myersCalcEditDistanceSemiGlobal(
  * alignData.
  * @return Status.
  */
-static int myersCalcEditDistanceNW(
-    const Word *const Peq, const int W, const int maxNumBlocks,
-    const int queryLength, const unsigned char *const target,
-    const int targetLength, int k, int *const bestScore_, int *const position_,
-    const bool findAlignment, AlignmentData **const alignData,
-    const int targetStopPosition) {
+template <class AlphabetIdx>
+int myersCalcEditDistanceNW(const Word *const Peq, const int W,
+                            const int maxNumBlocks, const int queryLength,
+                            const AlphabetIdx *const target,
+                            const int targetLength, int k,
+                            int *const bestScore_, int *const position_,
+                            const bool findAlignment,
+                            AlignmentData **const alignData,
+                            const int targetStopPosition) {
   if (targetStopPosition > -1 && findAlignment) {
     // They can not be both set at the same time!
     return EDLIB_STATUS_ERROR;
@@ -847,9 +916,9 @@ static int myersCalcEditDistanceNW(
   else
     *alignData = NULL;
 
-  const unsigned char *targetChar = target;
+  const AlphabetIdx *targetElement = target;
   for (int c = 0; c < targetLength; c++) { // for each column
-    const Word *Peq_c = Peq + *targetChar * maxNumBlocks;
+    const Word *Peq_c = Peq + *targetElement * maxNumBlocks;
 
     //----------------------- Calculate column -------------------------//
     int hout = 1;
@@ -921,7 +990,7 @@ static int myersCalcEditDistanceNW(
                                       // but more efficient reduction
       while (lastBlock >= firstBlock) {
         // If all cells outside of band, remove block
-        vector<int> scores = getBlockCellValues(*bl);
+        std::vector<int> scores = getBlockCellValues(*bl);
         int numCells =
             lastBlock == maxNumBlocks - 1 ? WORD_SIZE - W : WORD_SIZE;
         int r = lastBlock * WORD_SIZE + numCells - 1;
@@ -943,7 +1012,7 @@ static int myersCalcEditDistanceNW(
 
       while (firstBlock <= lastBlock) {
         // If all cells outside of band, remove block
-        vector<int> scores = getBlockCellValues(blocks[firstBlock]);
+        std::vector<int> scores = getBlockCellValues(blocks[firstBlock]);
         int numCells =
             firstBlock == maxNumBlocks - 1 ? WORD_SIZE - W : WORD_SIZE;
         int r = firstBlock * WORD_SIZE + numCells - 1;
@@ -999,7 +1068,7 @@ static int myersCalcEditDistanceNW(
     }
     //----------------------------------------------------//
 
-    targetChar++;
+    targetElement++;
   }
 
   if (lastBlock ==
@@ -1033,7 +1102,7 @@ static int myersCalcEditDistanceNW(
  * @param [out] alignmentLength  Length of alignment.
  * @return Status code.
  */
-static int obtainAlignmentTraceback(const int queryLength,
+inline int obtainAlignmentTraceback(const int queryLength,
                                     const int targetLength, const int bestScore,
                                     const AlignmentData *const alignData,
                                     unsigned char **const alignment,
@@ -1250,7 +1319,7 @@ static int obtainAlignmentTraceback(const int queryLength,
 
   *alignment = static_cast<unsigned char *>(
       realloc(*alignment, (*alignmentLength) * sizeof(unsigned char)));
-  reverse(*alignment, *alignment + (*alignmentLength));
+  std::reverse(*alignment, *alignment + (*alignmentLength));
   return EDLIB_STATUS_OK;
 }
 
@@ -1272,14 +1341,15 @@ static int obtainAlignmentTraceback(const int queryLength,
  * @param [out] alignmentLength  Length of alignment.
  * @return Status code.
  */
-static int
-obtainAlignment(const unsigned char *const query,
-                const unsigned char *const rQuery, const int queryLength,
-                const unsigned char *const target,
-                const unsigned char *const rTarget, const int targetLength,
-                const EqualityDefinition &equalityDefinition,
-                const int alphabetLength, const int bestScore,
-                unsigned char **const alignment, int *const alignmentLength) {
+template <class AlphabetIdx>
+int obtainAlignment(const AlphabetIdx *const query,
+                    const AlphabetIdx *const rQuery, const int queryLength,
+                    const AlphabetIdx *const target,
+                    const AlphabetIdx *const rTarget, const int targetLength,
+                    const EqualityDefinition<AlphabetIdx> &equalityDefinition,
+                    const int alphabetLength, const int bestScore,
+                    unsigned char **const alignment,
+                    int *const alignmentLength) {
 
   // Handle special case when one of sequences has length of 0.
   if (queryLength == 0 || targetLength == 0) {
@@ -1313,11 +1383,11 @@ obtainAlignment(const unsigned char *const query,
   if (alignmentDataSize < 1024 * 1024) {
     int score_, endLocation_; // Used only to call function.
     AlignmentData *alignData = NULL;
-    Word *Peq =
-        buildPeq(alphabetLength, query, queryLength, equalityDefinition);
-    myersCalcEditDistanceNW(Peq, W, maxNumBlocks, queryLength, target,
-                            targetLength, bestScore, &score_, &endLocation_,
-                            true, &alignData, -1);
+    Word *Peq = buildPeq<AlphabetIdx>(alphabetLength, query, queryLength,
+                                      equalityDefinition);
+    myersCalcEditDistanceNW<AlphabetIdx>(
+        Peq, W, maxNumBlocks, queryLength, target, targetLength, bestScore,
+        &score_, &endLocation_, true, &alignData, -1);
     // assert(score_ == bestScore);
     // assert(endLocation_ == targetLength - 1);
 
@@ -1327,7 +1397,7 @@ obtainAlignment(const unsigned char *const query,
     delete alignData;
     delete[] Peq;
   } else {
-    statusCode = obtainAlignmentHirschberg(
+    statusCode = obtainAlignmentHirschberg<AlphabetIdx>(
         query, rQuery, queryLength, target, rTarget, targetLength,
         equalityDefinition, alphabetLength, bestScore, alignment,
         alignmentLength);
@@ -1352,20 +1422,22 @@ obtainAlignment(const unsigned char *const query,
  * @param [out] alignmentLength  Length of alignment.
  * @return Status code.
  */
-static int obtainAlignmentHirschberg(
-    const unsigned char *const query, const unsigned char *const rQuery,
-    const int queryLength, const unsigned char *const target,
-    const unsigned char *const rTarget, const int targetLength,
-    const EqualityDefinition &equalityDefinition, const int alphabetLength,
-    const int bestScore, unsigned char **const alignment,
-    int *const alignmentLength) {
+template <class AlphabetIdx>
+int obtainAlignmentHirschberg(
+    const AlphabetIdx *const query, const AlphabetIdx *const rQuery,
+    const int queryLength, const AlphabetIdx *const target,
+    const AlphabetIdx *const rTarget, const int targetLength,
+    const EqualityDefinition<AlphabetIdx> &equalityDefinition,
+    const int alphabetLength, const int bestScore,
+    unsigned char **const alignment, int *const alignmentLength) {
 
   const int maxNumBlocks = ceilDiv(queryLength, WORD_SIZE);
   const int W = maxNumBlocks * WORD_SIZE - queryLength;
 
-  Word *Peq = buildPeq(alphabetLength, query, queryLength, equalityDefinition);
-  Word *rPeq =
-      buildPeq(alphabetLength, rQuery, queryLength, equalityDefinition);
+  Word *Peq = buildPeq<AlphabetIdx>(alphabetLength, query, queryLength,
+                                    equalityDefinition);
+  Word *rPeq = buildPeq<AlphabetIdx>(alphabetLength, rQuery, queryLength,
+                                     equalityDefinition);
 
   // Used only to call functions.
   int score_, endLocation_;
@@ -1376,13 +1448,13 @@ static int obtainAlignmentHirschberg(
 
   // Calculate left half.
   AlignmentData *alignDataLeftHalf = NULL;
-  int leftHalfCalcStatus = myersCalcEditDistanceNW(
+  int leftHalfCalcStatus = myersCalcEditDistanceNW<AlphabetIdx>(
       Peq, W, maxNumBlocks, queryLength, target, targetLength, bestScore,
       &score_, &endLocation_, false, &alignDataLeftHalf, leftHalfWidth - 1);
 
   // Calculate right half.
   AlignmentData *alignDataRightHalf = NULL;
-  int rightHalfCalcStatus = myersCalcEditDistanceNW(
+  int rightHalfCalcStatus = myersCalcEditDistanceNW<AlphabetIdx>(
       rPeq, W, maxNumBlocks, queryLength, rTarget, targetLength, bestScore,
       &score_, &endLocation_, false, &alignDataRightHalf, rightHalfWidth - 1);
 
@@ -1513,16 +1585,16 @@ static int obtainAlignmentHirschberg(
   const int lrWidth = rightHalfWidth;
   unsigned char *ulAlignment = NULL;
   int ulAlignmentLength;
-  int ulStatusCode = obtainAlignment(
+  int ulStatusCode = obtainAlignment<AlphabetIdx>(
       query, rQuery + lrHeight, ulHeight, target, rTarget + lrWidth, ulWidth,
       equalityDefinition, alphabetLength, leftScore, &ulAlignment,
       &ulAlignmentLength);
   unsigned char *lrAlignment = NULL;
   int lrAlignmentLength;
-  int lrStatusCode =
-      obtainAlignment(query + ulHeight, rQuery, lrHeight, target + ulWidth,
-                      rTarget, lrWidth, equalityDefinition, alphabetLength,
-                      rightScore, &lrAlignment, &lrAlignmentLength);
+  int lrStatusCode = obtainAlignment<AlphabetIdx>(
+      query + ulHeight, rQuery, lrHeight, target + ulWidth, rTarget, lrWidth,
+      equalityDefinition, alphabetLength, rightScore, &lrAlignment,
+      &lrAlignmentLength);
   if (ulStatusCode == EDLIB_STATUS_ERROR ||
       lrStatusCode == EDLIB_STATUS_ERROR) {
     if (ulAlignment)
@@ -1546,15 +1618,13 @@ static int obtainAlignmentHirschberg(
 }
 
 /**
- * Takes char query and char target, recognizes alphabet and transforms them
- * into unsigned char sequences where elements in sequences are not any more
- * letters of alphabet, but their index in alphabet. Most of internal edlib
- * functions expect such transformed sequences. This function will allocate
- * queryTransformed and targetTransformed, so make sure to free them when done.
- * Example:
- *   Original sequences: "ACT" and "CGT".
- *   Alphabet would be recognized as "ACTG". Alphabet length = 4.
- *   Transformed sequences: [0, 1, 2] and [1, 3, 2].
+ * Takes query and target, recognizes alphabet and transforms them into index
+ * sequences where elements in sequences are not any more letters of alphabet,
+ * but their index in alphabet. Most of internal edlib functions expect such
+ * transformed sequences. This function will allocate queryTransformed and
+ * targetTransformed, so make sure to free them when done. Example: Original
+ * sequences: "ACT" and "CGT". Alphabet would be recognized as "ACTG". Alphabet
+ * length = 4. Transformed sequences: [0, 1, 2] and [1, 3, 2].
  * @param [in] queryOriginal
  * @param [in] queryLength
  * @param [in] targetOriginal
@@ -1563,61 +1633,107 @@ static int obtainAlignmentHirschberg(
  * length - 1].
  * @param [out] targetTransformed  It will contain values in range [0, alphabet
  * length - 1].
- * @return  Alphabet as a string of unique characters, where index of each
- * character is its value in transformed sequences.
+ * @return  Alphabet as an unordered_map having unique elements as keys and
+ * their indexes as values, where index of each element is its value in
+ * transformed sequences.
+ * @throw   AlphabetTooBig exception if the size of alphabet is larger than the
+ * maximum value of AlphabetIdx type.
  */
-static string transformSequences(const char *const queryOriginal,
-                                 const int queryLength,
-                                 const char *const targetOriginal,
-                                 const int targetLength,
-                                 unsigned char **const queryTransformed,
-                                 unsigned char **const targetTransformed) {
+template <class Element, class AlphabetIdx>
+std::unordered_map<Element, AlphabetIdx>
+transformSequences(const Element *const queryOriginal, const int queryLength,
+                   const Element *const targetOriginal, const int targetLength,
+                   AlphabetIdx **const queryTransformed,
+                   AlphabetIdx **const targetTransformed) {
   // Alphabet is constructed from letters that are present in sequences.
   // Each letter is assigned an ordinal number, starting from 0 up to
   // alphabetLength - 1, and new query and target are created in which letters
   // are replaced with their ordinal numbers. This query and target are used in
   // all the calculations later.
   *queryTransformed =
-      static_cast<unsigned char *>(malloc(sizeof(unsigned char) * queryLength));
-  *targetTransformed = static_cast<unsigned char *>(
-      malloc(sizeof(unsigned char) * targetLength));
+      static_cast<AlphabetIdx *>(malloc(sizeof(AlphabetIdx) * queryLength));
+  *targetTransformed =
+      static_cast<AlphabetIdx *>(malloc(sizeof(AlphabetIdx) * targetLength));
 
-  string alphabet = "";
+  std::unordered_map<Element, AlphabetIdx> elementToAlphabetIdx;
 
   // Alphabet information, it is constructed on fly while transforming
-  // sequences. letterIdx[c] is index of letter c in alphabet.
-  unsigned char letterIdx[MAX_UCHAR + 1];
-  bool inAlphabet[MAX_UCHAR + 1]; // inAlphabet[c] is true if c is in alphabet
-  for (int i = 0; i < MAX_UCHAR + 1; i++)
-    inAlphabet[i] = false;
-
+  // sequences. elementToAlphabetIdx[c] is index of letter c in alphabet.
+  AlphabetIdx currentSize = 0;
   for (int i = 0; i < queryLength; i++) {
-    unsigned char c = static_cast<unsigned char>(queryOriginal[i]);
-    if (!inAlphabet[c]) {
-      inAlphabet[c] = true;
-      letterIdx[c] = static_cast<unsigned char>(alphabet.size());
-      alphabet += queryOriginal[i];
+    Element c = queryOriginal[i];
+    auto iter = elementToAlphabetIdx.find(c);
+    if (iter == elementToAlphabetIdx
+                    .end()) { // if the element is not inserted previously
+      if (currentSize == (std::numeric_limits<AlphabetIdx>::max() -
+                          1)) { // -1 is because of wildcard
+        throw AlphabetTooBigException();
+      }
+      elementToAlphabetIdx[c] = currentSize;
+      (*queryTransformed)[i] = currentSize;
+      currentSize++;
+    } else {
+      (*queryTransformed)[i] = iter->second;
     }
-    (*queryTransformed)[i] = letterIdx[c];
   }
   for (int i = 0; i < targetLength; i++) {
-    unsigned char c = static_cast<unsigned char>(targetOriginal[i]);
-    if (!inAlphabet[c]) {
-      inAlphabet[c] = true;
-      letterIdx[c] = static_cast<unsigned char>(alphabet.size());
-      alphabet += targetOriginal[i];
+    Element c = targetOriginal[i];
+    auto iter = elementToAlphabetIdx.find(c);
+    if (iter == elementToAlphabetIdx
+                    .end()) { // if the element is not inserted previously
+      if (currentSize == (std::numeric_limits<AlphabetIdx>::max() -
+                          1)) { // -1 is because of wildcard
+        throw AlphabetTooBigException();
+      }
+      elementToAlphabetIdx[c] = currentSize;
+      (*targetTransformed)[i] = currentSize;
+      currentSize++;
+    } else {
+      (*targetTransformed)[i] = iter->second;
     }
-    (*targetTransformed)[i] = letterIdx[c];
   }
 
-  return alphabet;
+  return elementToAlphabetIdx;
 }
 
-extern "C" EdlibAlignConfig
+/**
+ * Takes additional equalities for alphabet elements, transforms them into index
+ * equalities
+ * @param [in] additionalEqualities
+ * @param [in] additionalEqualitiesLength
+ * @param [in] elementToAlphabetIdx
+ * @return  transformedEqualities A vector of pairs in which each pair contains
+ * the indexes of an additional equality
+ */
+template <class Element, class AlphabetIdx>
+std::vector<EdlibEqualityPair<AlphabetIdx>> transformEqualityPairs(
+    const EdlibEqualityPair<Element> *additionalEqualities,
+    int additionalEqualitiesLength,
+    const std::unordered_map<Element, AlphabetIdx> &elementToAlphabetIdx) {
+  std::vector<EdlibEqualityPair<AlphabetIdx>> transformedEqualities;
+  for (int i = 0; i < additionalEqualitiesLength; i++) {
+    Element a = additionalEqualities[i].first;
+    Element b = additionalEqualities[i].second;
+    if (elementToAlphabetIdx.count(a) && elementToAlphabetIdx.count(b)) {
+      EdlibEqualityPair<AlphabetIdx> transformedEquality;
+      transformedEquality.first = elementToAlphabetIdx.at(a);
+      transformedEquality.second = elementToAlphabetIdx.at(b);
+      transformedEqualities.push_back(transformedEquality);
+    } else {
+      continue;
+    }
+  }
+  return transformedEqualities;
+}
+
+} // namespace internal
+
+template <class Element>
+EdlibAlignConfig<Element>
 edlibNewAlignConfig(int k, EdlibAlignMode mode, EdlibAlignTask task,
-                    const EdlibEqualityPair *additionalEqualities,
+                    const EdlibEqualityPair<Element> *additionalEqualities,
                     int additionalEqualitiesLength) {
-  EdlibAlignConfig config;
+  EdlibAlignConfig<Element> config;
   config.k = k;
   config.mode = mode;
   config.task = task;
@@ -1626,11 +1742,13 @@ edlibNewAlignConfig(int k, EdlibAlignMode mode, EdlibAlignTask task,
   return config;
 }
 
-extern "C" EdlibAlignConfig edlibDefaultAlignConfig(void) {
-  return edlibNewAlignConfig(-1, EDLIB_MODE_NW, EDLIB_TASK_DISTANCE, NULL, 0);
+template <class Element>
+EdlibAlignConfig<Element> edlibDefaultAlignConfig(void) {
+  return edlibNewAlignConfig<Element>(-1, EDLIB_MODE_NW, EDLIB_TASK_DISTANCE,
+                                      NULL, 0);
 }
 
-extern "C" void edlibFreeAlignResult(EdlibAlignResult result) {
+inline void edlibFreeAlignResult(EdlibAlignResult result) {
   if (result.endLocations)
     free(result.endLocations);
   if (result.startLocations)
@@ -1638,3 +1756,5 @@ extern "C" void edlibFreeAlignResult(EdlibAlignResult result) {
   if (result.alignment)
     free(result.alignment);
 }
+} // namespace edlib
+#endif // TEXTSEARCH_CSRC_DLIB_INL_H_

--- a/textsearch/csrc/edlib_test.cc
+++ b/textsearch/csrc/edlib_test.cc
@@ -1,0 +1,727 @@
+// Copied and modified from
+// https://github.com/Martinsos/edlib/blob/master/test/SimpleEditDistance.h and
+// https://github.com/Martinsos/edlib/blob/master/test/runTests.cpp
+//
+#include <gtest/gtest.h>
+
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <vector>
+
+#include "textsearch/csrc/edlib.h"
+
+using namespace std;
+
+static int max(int a, int b) { return a > b ? a : b; }
+
+static int min(int x, int y) { return x < y ? x : y; }
+
+static int min3(int x, int y, int z) { return min(x, min(y, z)); }
+
+static int calcEditDistanceSimple(const char *query, int queryLength,
+                                  const char *target, int targetLength,
+                                  const EdlibAlignMode mode, int *score,
+                                  int **positions_, int *numPositions_) {
+  int bestScore = -1;
+  vector<int> positions;
+
+  // Handle as a special situation when one of the sequences has length 0.
+  if (queryLength == 0 || targetLength == 0) {
+    if (mode == EDLIB_MODE_NW) {
+      *score = std::max(queryLength, targetLength);
+      *positions_ = new int[1];
+      *positions_[0] = targetLength - 1;
+      *numPositions_ = 1;
+    } else if (mode == EDLIB_MODE_SHW || mode == EDLIB_MODE_HW) {
+      *score = queryLength;
+      *positions_ = new int[1];
+      *positions_[0] = -1;
+      *numPositions_ = 1;
+    } else {
+      return EDLIB_STATUS_ERROR;
+    }
+    return EDLIB_STATUS_OK;
+  }
+
+  int *C = new int[queryLength];
+  int *newC = new int[queryLength];
+
+  // set first column (column zero)
+  for (int i = 0; i < queryLength; i++) {
+    C[i] = i + 1;
+  }
+  for (int c = 0; c < targetLength; c++) {                  // for each column
+    newC[0] = min3((mode == EDLIB_MODE_HW ? 0 : c + 1) + 1, // up
+                   (mode == EDLIB_MODE_HW ? 0 : c) +
+                       (target[c] == query[0] ? 0 : 1), // up left
+                   C[0] + 1);                           // left
+    for (int r = 1; r < queryLength; r++) {
+      newC[r] = min3(newC[r - 1] + 1,                            // up
+                     C[r - 1] + (target[c] == query[r] ? 0 : 1), // up left
+                     C[r] + 1);                                  // left
+    }
+
+    if (mode != EDLIB_MODE_NW ||
+        c == targetLength - 1) { // For NW check only last column
+      int newScore = newC[queryLength - 1];
+      if (bestScore == -1 || newScore <= bestScore) {
+        if (newScore < bestScore) {
+          positions.clear();
+        }
+        bestScore = newScore;
+        positions.push_back(c);
+      }
+    }
+
+    int *tmp = C;
+    C = newC;
+    newC = tmp;
+  }
+
+  delete[] C;
+  delete[] newC;
+
+  *score = bestScore;
+  if (positions.size() > 0) {
+    *positions_ = new int[positions.size()];
+    *numPositions_ = static_cast<int>(positions.size());
+    copy(positions.begin(), positions.end(), *positions_);
+  } else {
+    *positions_ = NULL;
+    *numPositions_ = 0;
+  }
+
+  return EDLIB_STATUS_OK;
+}
+
+static bool checkAlignment(const char *query, int queryLength,
+                           const char *target, int score, int pos,
+                           EdlibAlignMode mode, unsigned char *alignment,
+                           int alignmentLength) {
+  int alignScore = 0;
+  int qIdx = queryLength - 1;
+  int tIdx = pos;
+  for (int i = alignmentLength - 1; i >= 0; i--) {
+    if (alignment[i] == EDLIB_EDOP_MATCH) { // match
+      if (query[qIdx] != target[tIdx]) {
+        printf("Should be match but is a mismatch! (tIdx, qIdx, i): (%d, %d, "
+               "%d)\n",
+               tIdx, qIdx, i);
+        return false;
+      }
+      qIdx--;
+      tIdx--;
+    } else if (alignment[i] == EDLIB_EDOP_MISMATCH) { // mismatch
+      if (query[qIdx] == target[tIdx]) {
+        printf("Should be mismatch but is a match! (tIdx, qIdx, i): (%d, %d, "
+               "%d)\n",
+               tIdx, qIdx, i);
+        return false;
+      }
+      alignScore += 1;
+      qIdx--;
+      tIdx--;
+    } else if (alignment[i] == EDLIB_EDOP_INSERT) {
+      alignScore += 1;
+      qIdx--;
+    } else if (alignment[i] == EDLIB_EDOP_DELETE) {
+      if (!(mode == EDLIB_MODE_HW && qIdx == -1))
+        alignScore += 1;
+      tIdx--;
+    }
+    if (tIdx < -1 || qIdx < -1) {
+      printf(
+          "Alignment went outside of matrix! (tIdx, qIdx, i): (%d, %d, %d)\n",
+          tIdx, qIdx, i);
+      return false;
+    }
+  }
+  if (qIdx != -1) {
+    printf("Alignment did not reach end!\n");
+    return false;
+  }
+  if (alignScore != score) {
+    printf("Wrong score in alignment! %d should be %d\n", alignScore, score);
+    return false;
+  }
+  if (alignmentLength > 0 && alignment[0] == EDLIB_EDOP_INSERT && tIdx >= 0) {
+    printf("Alignment starts with insertion in target, while it could start "
+           "with mismatch!\n");
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @param alignment
+ * @param alignmentLength
+ * @param endLocation
+ * @return Return start location of alignment in target, if there is none return
+ * -1.
+ */
+static int getAlignmentStart(const unsigned char *alignment,
+                             int alignmentLength, int endLocation) {
+  int startLocation = endLocation + 1;
+  for (int i = 0; i < alignmentLength; i++) {
+    if (alignment[i] != EDLIB_EDOP_INSERT) {
+      startLocation--;
+    }
+  }
+  if (startLocation > endLocation) {
+    return -1;
+  }
+  return startLocation;
+}
+
+static bool executeTest(const char *query, int queryLength, const char *target,
+                        int targetLength, EdlibAlignMode mode) {
+  bool pass = true;
+
+  int scoreSimple = -1;
+  int numLocationsSimple = 0;
+  int *endLocationsSimple = NULL;
+  calcEditDistanceSimple(query, queryLength, target, targetLength, mode,
+                         &scoreSimple, &endLocationsSimple,
+                         &numLocationsSimple);
+
+  EdlibAlignResult result =
+      edlibAlign(query, queryLength, target, targetLength,
+                 edlibNewAlignConfig(-1, mode, EDLIB_TASK_PATH, NULL, 0));
+
+  if (result.editDistance != scoreSimple) {
+    pass = false;
+    printf("Scores: expected %d, got %d\n", scoreSimple, result.editDistance);
+  } else if (result.numLocations != numLocationsSimple) {
+    pass = false;
+    printf("Number of locations: expected %d, got %d\n", numLocationsSimple,
+           result.numLocations);
+  } else {
+    for (int i = 0; i < result.numLocations; i++) {
+      if (result.endLocations[i] != endLocationsSimple[i]) {
+        pass = false;
+        printf("End locations at %d are not equal! Expected %d, got %d\n", i,
+               endLocationsSimple[i], result.endLocations[1]);
+        break;
+      }
+    }
+  }
+  if (result.alignment) {
+    if (!checkAlignment(query, queryLength, target, result.editDistance,
+                        result.endLocations[0], mode, result.alignment,
+                        result.alignmentLength)) {
+      pass = false;
+      printf("Alignment is not correct\n");
+    }
+    int alignmentStart = getAlignmentStart(
+        result.alignment, result.alignmentLength, result.endLocations[0]);
+    if (result.startLocations[0] != alignmentStart) {
+      pass = false;
+      printf(
+          "Start location (%d) is not consistent with alignment start (%d)\n",
+          result.startLocations[0], alignmentStart);
+    }
+  }
+
+  delete[] endLocationsSimple;
+  edlibFreeAlignResult(result);
+  return pass;
+}
+
+static void fillRandomly(char *seq, int seqLength, int alphabetLength) {
+  for (int i = 0; i < seqLength; i++)
+    seq[i] = static_cast<char>(rand()) % alphabetLength;
+}
+
+// Returns true if all tests passed, false otherwise.
+static bool runRandomTests(int numTests, EdlibAlignMode mode,
+                           bool findAlignment) {
+  int alphabetLength = 10;
+  int numTestsFailed = 0;
+  clock_t start;
+  double timeEdlib = 0;
+  double timeSimple = 0;
+
+  for (int i = 0; i < numTests; i++) {
+    bool failed = false;
+    int queryLength = 50 + rand() % 300;
+    int targetLength = 500 + rand() % 10000;
+    char *query = static_cast<char *>(malloc(sizeof(char) * queryLength));
+    char *target = static_cast<char *>(malloc(sizeof(char) * targetLength));
+    fillRandomly(query, queryLength, alphabetLength);
+    fillRandomly(target, targetLength, alphabetLength);
+
+    start = clock();
+    EdlibAlignResult result = edlibAlign(
+        query, queryLength, target, targetLength,
+        edlibNewAlignConfig(
+            -1, mode, findAlignment ? EDLIB_TASK_PATH : EDLIB_TASK_DISTANCE,
+            NULL, 0));
+    timeEdlib += clock() - start;
+    if (result.alignment) {
+      if (!checkAlignment(query, queryLength, target, result.editDistance,
+                          result.endLocations[0], mode, result.alignment,
+                          result.alignmentLength)) {
+        failed = true;
+        printf("Alignment is not correct\n");
+      }
+      int alignmentStart = getAlignmentStart(
+          result.alignment, result.alignmentLength, result.endLocations[0]);
+      if (result.startLocations[0] != alignmentStart) {
+        failed = true;
+        printf(
+            "Start location (%d) is not consistent with alignment start (%d)\n",
+            result.startLocations[0], alignmentStart);
+      }
+    }
+
+    start = clock();
+    int score2;
+    int numLocations2;
+    int *endLocations2;
+    calcEditDistanceSimple(query, queryLength, target, targetLength, mode,
+                           &score2, &endLocations2, &numLocations2);
+    timeSimple += clock() - start;
+
+    // Compare results
+    if (result.editDistance != score2) {
+      failed = true;
+      printf("Scores are different! Expected %d, got %d)\n", score2,
+             result.editDistance);
+    } else if (result.editDistance == -1 && !(result.endLocations == NULL)) {
+      failed = true;
+      printf("Score was not found but endLocations is not NULL!\n");
+    } else if (result.numLocations != numLocations2) {
+      failed = true;
+      printf(
+          "Number of endLocations returned is not equal! Expected %d, got %d\n",
+          numLocations2, result.numLocations);
+    } else {
+      for (int j = 0; j < result.numLocations; j++) {
+        if (result.endLocations[j] != endLocations2[j]) {
+          failed = true;
+          printf("EndLocations at %d are not equal! Expected %d, got %d\n", j,
+                 endLocations2[j], result.endLocations[j]);
+          break;
+        }
+      }
+    }
+
+    edlibFreeAlignResult(result);
+    if (endLocations2)
+      delete[] endLocations2;
+
+    for (int k = max(score2 - 1, 0); k <= score2 + 1; k++) {
+      int scoreExpected = score2 > k ? -1 : score2;
+      EdlibAlignResult result3 = edlibAlign(
+          query, queryLength, target, targetLength,
+          edlibNewAlignConfig(
+              k, mode, findAlignment ? EDLIB_TASK_PATH : EDLIB_TASK_DISTANCE,
+              NULL, 0));
+      if (result3.editDistance != scoreExpected) {
+        failed = true;
+        printf("For k = %d score was %d but it should have been %d\n", k,
+               result3.editDistance, scoreExpected);
+      }
+      if (result3.alignment) {
+        if (!checkAlignment(query, queryLength, target, result3.editDistance,
+                            result3.endLocations[0], mode, result3.alignment,
+                            result3.alignmentLength)) {
+          failed = true;
+          printf("Alignment is not correct\n");
+        }
+        int alignmentStart =
+            getAlignmentStart(result3.alignment, result3.alignmentLength,
+                              result3.endLocations[0]);
+        if (result3.startLocations[0] != alignmentStart) {
+          failed = true;
+          printf("Start location (%d) is not consistent with alignment start "
+                 "(%d)\n",
+                 result3.startLocations[0], alignmentStart);
+        }
+      }
+      edlibFreeAlignResult(result3);
+    }
+
+    if (failed)
+      numTestsFailed++;
+
+    free(query);
+    free(target);
+  }
+
+  printf(mode == EDLIB_MODE_HW ? "HW: "
+                               : mode == EDLIB_MODE_SHW ? "SHW: " : "NW: ");
+  printf(numTestsFailed == 0 ? "\x1B[32m" : "\x1B[31m");
+  printf("%d/%d", numTests - numTestsFailed, numTests);
+  printf("\x1B[0m");
+  printf(" random tests passed!\n");
+  double mTime = static_cast<double>(timeEdlib) / CLOCKS_PER_SEC;
+  double sTime = static_cast<double>(timeSimple) / CLOCKS_PER_SEC;
+  printf("Time Edlib: %lf\n", mTime);
+  printf("Time Simple: %lf\n", sTime);
+  printf("Times faster: %.2lf\n", sTime / mTime);
+  return numTestsFailed == 0;
+}
+
+TEST(EdlibTest, TestEmpty) {
+  const char *emptySeq = "";
+  const char *nonEmptySeq = "ACTG";
+  const int nonEmptySeqLength = 4;
+
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(executeTest(emptySeq, 0, nonEmptySeq, nonEmptySeqLength, mode));
+    EXPECT_TRUE(executeTest(nonEmptySeq, nonEmptySeqLength, emptySeq, 0, mode));
+  }
+}
+
+TEST(EdlibTest, TestBasic1) {
+  int queryLength = 4;
+  int targetLength = 4;
+  char query[4] = {0, 1, 2, 3};
+  char target[4] = {0, 1, 2, 3};
+
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(executeTest(query, queryLength, target, targetLength, mode));
+  }
+}
+
+TEST(EdlibTest, TestBasic2) {
+  int queryLength = 5;
+  int targetLength = 9;
+  char query[5] = {0, 1, 2, 3, 4};              // "match"
+  char target[9] = {8, 5, 0, 1, 3, 4, 6, 7, 5}; // "remachine"
+
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(executeTest(query, queryLength, target, targetLength, mode));
+  }
+}
+
+TEST(EdlibTest, TestBasic3) {
+  int queryLength = 5;
+  int targetLength = 9;
+  char query[5] = {0, 1, 2, 3, 4};
+  char target[9] = {1, 2, 0, 1, 2, 3, 4, 5, 4};
+
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(executeTest(query, queryLength, target, targetLength, mode));
+  }
+}
+
+TEST(EdlibTest, TestBasic4) {
+  int queryLength = 200;
+  int targetLength = 200;
+  char query[200] = {0};
+  char target[200] = {1};
+
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(executeTest(query, queryLength, target, targetLength, mode));
+  }
+}
+
+TEST(EdlibTest, TestBasic5) {
+  int queryLength =
+      64; // Testing for special case when queryLength == word size
+  int targetLength = 64;
+  char query[64] = {0};
+  char target[64] = {1};
+
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(executeTest(query, queryLength, target, targetLength, mode));
+  }
+}
+
+TEST(EdlibTest, TestBasic6) {
+  int queryLength =
+      13; // Testing for special case when queryLength == word size
+  int targetLength = 420;
+  char query[13] = {1, 3, 0, 1, 1, 1, 3, 0, 1, 3, 1, 3, 3};
+  char target[420] = {
+      0, 1, 1, 1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3, 3, 1, 0, 1, 1, 1,
+      0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3, 3, 1, 0, 1, 1, 1, 0, 1, 3, 0,
+      1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3, 3, 1, 0, 1, 1, 1, 0, 1, 3, 0, 1, 3, 3, 3,
+      1, 3, 2, 2, 3, 2, 3, 3, 1, 0, 1, 1, 1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2, 2,
+      3, 2, 3, 3, 1, 0, 1, 1, 1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3, 3,
+      1, 0, 1, 1, 1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3, 3, 1, 0, 1, 1,
+      1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3, 3, 1, 0, 1, 1, 1, 0, 1, 3,
+      0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3, 3, 1, 0, 1, 1, 1, 0, 1, 3, 0, 1, 3, 3,
+      3, 1, 3, 2, 2, 3, 2, 3, 3, 1, 0, 1, 1, 1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2,
+      2, 3, 2, 3, 3, 1, 0, 1, 1, 1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3,
+      3, 1, 0, 1, 1, 1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3, 3, 1, 0, 1,
+      1, 1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3, 3, 1, 0, 1, 1, 1, 0, 1,
+      3, 0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3, 3, 1, 0, 1, 1, 1, 0, 1, 3, 0, 1, 3,
+      3, 3, 1, 3, 2, 2, 3, 2, 3, 3, 1, 0, 1, 1, 1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3,
+      2, 2, 3, 2, 3, 3, 1, 0, 1, 1, 1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2,
+      3, 3, 1, 0, 1, 1, 1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3, 3, 1, 0,
+      1, 1, 1, 0, 1, 3, 0, 1, 3, 3, 3, 1, 3, 2, 2, 3, 2, 3, 3, 1};
+
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(executeTest(query, queryLength, target, targetLength, mode));
+  }
+}
+
+TEST(EdlibTest, TestBasic7) {
+  int queryLength = 3;
+  int targetLength = 5;
+  char query[3] = {2, 3, 0};
+  char target[5] = {0, 1, 2, 2, 0};
+
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(executeTest(query, queryLength, target, targetLength, mode));
+  }
+}
+
+TEST(EdlibTest, TestBasic8) {
+  int queryLength = 3;
+  int targetLength = 3;
+  char query[3] = {2, 3, 0};
+  char target[3] = {2, 2, 0};
+
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(executeTest(query, queryLength, target, targetLength, mode));
+  }
+}
+
+TEST(EdlibTest, TestBasic9) {
+  int queryLength = 64;
+  int targetLength = 393;
+  char query[64] = {9, 5, 5, 9, 9, 4, 6, 0, 1, 1, 5, 4, 6, 0, 6, 5,
+                    5, 6, 5, 2, 2, 0, 6, 0, 8, 3, 7, 0, 6, 6, 4, 8,
+                    3, 1, 9, 4, 5, 5, 5, 7, 8, 2, 3, 6, 4, 1, 1, 2,
+                    7, 7, 6, 0, 9, 2, 0, 9, 6, 9, 9, 4, 6, 5, 2, 9};
+  char target[393] = {
+      7, 1, 6, 2, 9, 1, 1, 7, 5, 5, 4, 9, 6, 7, 3, 4, 6, 9, 4, 5, 2, 6, 6, 0, 7,
+      8, 4, 3, 3, 9, 5, 2, 0, 1, 7, 1, 4, 0, 9, 9, 7, 5, 0, 6, 2, 4, 0, 9, 3, 6,
+      6, 7, 4, 3, 9, 3, 3, 4, 7, 8, 5, 4, 1, 7, 7, 0, 9, 3, 0, 8, 4, 0, 3, 4, 6,
+      7, 0, 8, 6, 6, 6, 5, 5, 2, 0, 5, 5, 3, 1, 4, 1, 6, 8, 4, 3, 7, 6, 2, 0, 9,
+      0, 4, 9, 5, 1, 5, 3, 1, 3, 1, 9, 9, 6, 5, 1, 8, 0, 6, 1, 1, 1, 5, 9, 1, 1,
+      2, 1, 8, 5, 1, 7, 7, 8, 6, 5, 9, 1, 0, 2, 4, 1, 2, 5, 0, 9, 6, 8, 1, 4, 2,
+      4, 5, 9, 3, 9, 0, 5, 0, 8, 0, 3, 7, 0, 1, 3, 5, 0, 6, 5, 5, 2, 8, 9, 7, 0,
+      8, 5, 1, 9, 0, 3, 3, 7, 2, 6, 6, 4, 3, 8, 5, 6, 2, 2, 6, 5, 8, 3, 8, 4, 0,
+      3, 7, 8, 2, 6, 9, 0, 2, 0, 1, 2, 5, 6, 1, 9, 4, 8, 3, 7, 8, 8, 5, 2, 3, 1,
+      8, 1, 6, 6, 7, 6, 9, 6, 5, 3, 3, 6, 5, 7, 8, 6, 1, 3, 4, 2, 4, 0, 0, 7, 7,
+      1, 8, 5, 3, 3, 6, 1, 4, 5, 7, 3, 1, 8, 0, 8, 1, 5, 6, 6, 2, 4, 4, 3, 9, 8,
+      7, 3, 8, 0, 3, 8, 1, 3, 3, 4, 6, 1, 8, 2, 6, 7, 5, 8, 6, 7, 8, 7, 4, 5, 6,
+      6, 9, 0, 1, 1, 1, 9, 4, 9, 1, 9, 9, 2, 2, 4, 8, 0, 6, 6, 4, 4, 4, 2, 2, 2,
+      9, 3, 1, 6, 8, 7, 2, 9, 8, 6, 0, 1, 7, 7, 2, 8, 6, 2, 2, 1, 6, 0, 3, 4, 9,
+      8, 9, 3, 2, 3, 5, 3, 6, 6, 9, 6, 6, 2, 6, 6, 0, 8, 7, 9, 5, 9, 7, 4, 3, 1,
+      7, 2, 1, 0, 6, 0, 0, 7, 5, 2, 1, 2, 6, 9, 1, 5, 6, 7};
+
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(executeTest(query, queryLength, target, targetLength, mode));
+  }
+}
+
+TEST(EdlibTest, TestBasic10) {
+  int queryLength = 3;
+  int targetLength = 3;
+  char query[3] = {0, 1, 2};
+  char target[3] = {1, 1, 1};
+
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(executeTest(query, queryLength, target, targetLength, mode));
+  }
+}
+
+TEST(EdlibTest, TestBasic11) {
+  int queryLength = 8;
+  int targetLength = 8;
+  // NOTE(Martin): I am using CHAR_MIN and CHAR_MAX because 'char' type is not
+  // guaranteed to be
+  //   signed or unsigned by compiler, we can't know if it is signed or
+  //   unsigned.
+  char query[8] = {CHAR_MIN, CHAR_MIN + (CHAR_MAX - CHAR_MIN) / 2, CHAR_MAX};
+  char target[8] = {CHAR_MIN, CHAR_MIN + (CHAR_MAX - CHAR_MIN) / 2 + 1,
+                    CHAR_MAX};
+
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(executeTest(query, queryLength, target, targetLength, mode));
+  }
+}
+
+TEST(EdlibTest, TestBasic12) {
+  EdlibEqualityPair additionalEqualities[24] = {
+      {'R', 'A'}, {'R', 'G'}, {'M', 'A'}, {'M', 'C'}, {'W', 'A'}, {'W', 'T'},
+      {'S', 'C'}, {'S', 'G'}, {'Y', 'C'}, {'Y', 'T'}, {'K', 'G'}, {'K', 'T'},
+      {'V', 'A'}, {'V', 'C'}, {'V', 'G'}, {'H', 'A'}, {'H', 'C'}, {'H', 'T'},
+      {'D', 'A'}, {'D', 'G'}, {'D', 'T'}, {'B', 'C'}, {'B', 'G'}, {'B', 'T'}};
+  const char *query = "GCATATCAATAAGCGGAGGA";
+  const char *target =
+      "TAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTATCGAATAAACTTGATGGGTTGTCGCTGGCTTC"
+      "TAGGAGCATGTGCACATCCGTCATTTTTATCCATCCACCTGTGCACCTTTTGTAGTCTTTGGAGGTAATAAG"
+      "CGTGAATCTATCGAGGTCCTCTGGTCCTCGGAAAGAGGTGTTTGCCATATGGCTCGCCTTTGATACTCGCGA"
+      "GTTACTCTAAGACTATGTCCTTTCATATACTACGAATGTAATAGAATGTATTCATTGGGCCTCAGTGCCTAT"
+      "AAAACATATACAACTTTCAGCAACGGATCTCTTGGCTCTCGCATCGATGAAGAACGCAGCGAAATGCGATAA"
+      "GTAATGTGAATTGCAGAATTCAGTGAATCATCGAATCTTTGAACGCACCTTGCGCTCCTTGGTATTCCGAGG"
+      "AGCATGCCTGTTTGAGTGTCATTAAATTCTCAACCCCTTCCGGTTTTTTGACTGGCTTTGGGGCTTGGATGT"
+      "GGGGGATTCATTTGCGGGCCTCTGTAGAGGTCGGCTCCCCTGAAATGCATTAGTGGAACCGTTTGCGGTTAC"
+      "CGTCGCTGGTGTGATAACTATCTATGCCAAAGACAAACTGCTCTCTGATAGTTCTGCTTCTAACCGTCCATT"
+      "TATTGGACAACATTATTATGAACACTTGACCTCAAATCAGGTAGGACTACCCGCTGAACTTAAGCATATCAA"
+      "TAAGCGGAGGAAAAGAAACTAACAAGGATTCCCCTAGTAACTGCGAGTGAAGCGGGAAAAGCTCAAATTTAA"
+      "AATCTGGCGGTCTTTGGCCGTCCGAGTTGTAATCTAGAGAAGCGACACCCGCGCTGGACCGTGTACAAGTCT"
+      "CCTGGAATGGAGCGTCATAGAGGGTGAGAATCCCGTCTCTGACACGGACTACCAGGGCTTTGTGGTGCGCTC"
+      "TCAAAGAGTCGAGTTGTTTGGGAATGCAGCTCTAAATGGGTGGTAAATTCCATCTAAAGCTAAATATTGGCG"
+      "AGAGACCGATAGCGAACAAGTACCGTGAGGGAAAGATGAAAAGAACTTTGGAAAGAGAGTTAAACAGTACGT"
+      "GAAATTGCTGAAAGGGAAACGCTTGAAGTCAGTCGCGTTGGCCGGGGATCAGCCTCGCTTTTGCGTGGTGTA"
+      "TTTCCTGGTTGACGGGTCAGCATCAATTTTGACCGCTGGAAAAGGACTTGGGGAATGTGGCATCTTCGGATG"
+      "TGTTATAGCCCTTTGTCGCATACGGCGGTTGGGATTGAGGAACTCAGCACGCCGCAAGGCCGGGTTTCGACC"
+      "ACGTTCGTGCTTAGGATGCTGGCATAATGGCTTTAATCGACCCGTCTTGAAACACGGACCAAGGAGTCTAAC"
+      "ATGCCTGCGAGTGTTTGGGTGGAAAACCCGAGCGCGTAATGAAAGTGAAAGTTGAGATCCCTGTCGTGGGGA"
+      "GCATCGACGCCCGGACCAGAACTTTTGGGACGGATCTGCGGTAGAGCATGTATGTTGGGACCCGAAAGATGG"
+      "TGAACTATGCCTGAATAGGGTGAAGCCAGAGGAAACTCTGGTGGAGGCTCGTAGCGATTCTGACGTGCAAAT"
+      "CGATCGTCAAATTTGGGTATAGGGGCGAAAGACTAATCGAACCATCTAGTAGCTGGTTCCTGCCGAAGTTTC"
+      "CCTCAGGATAGCAGAAACTCATATCAGATTTATGTGGTAAAGCGAATGATTAGAGGCCTTGGGGTTGAAACA"
+      "ACCTTAACCTATTCTCAAACTTTAAATATGTAAGAACGAGCCGTTTCTTGATTGAACCGCTCGGCGATTGAG"
+      "AGTTTCTAGTGGGCCATTTTTGGTAAGCAGAACTGGCGATGCGGGATGAACCGAACGCGAGGTTAAGGTGCC"
+      "GGAATTCACGCTCATCAGACACCACAAAAGGTGTTAGTTCATCTAGACAGCAGGACGGTGGCCATGGAAGTC"
+      "GGAATCCGCTAAGGAGTGTGTAACAACTCACCTGCCGAATGAACTAGCCCTGAAAATGGATGGCGCTTAAGC"
+      "GTGATACCCATACCTCGCCGTCAGCGTTGAAGTGACGCGCTGACGAGTAGGCAGGCGTGGAGGTCAGTGAAG"
+      "AAGCCTTGGCAGTGATGCTGGGTGAAACGGCCTCC";
+
+  EdlibAlignResult result =
+      edlibAlign(query, static_cast<int>(std::strlen(query)), target,
+                 static_cast<int>(std::strlen(target)),
+                 edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_LOC,
+                                     additionalEqualities, 24));
+  bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 0;
+  edlibFreeAlignResult(result);
+  EXPECT_TRUE(pass);
+}
+
+TEST(EdlibTest, TestBasic13) {
+  // In this test, one of optimal solutions is:
+  //         B
+  //       AA
+  // which brings us into interesting situation where one of end locations is
+  // -1.
+  const char *query = "AA";
+  const char *target = "B";
+
+  EdlibAlignResult result = edlibAlign(
+      query, static_cast<int>(std::strlen(query)), target,
+      static_cast<int>(std::strlen(target)),
+      edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_PATH, NULL, 0));
+  bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 2;
+  edlibFreeAlignResult(result);
+  EXPECT_TRUE(pass);
+}
+
+TEST(EdlibTest, TestBasic14) {
+  // In this test, one of optimal solutions is:
+  //         B
+  //       AA
+  // which brings us into interesting situation where one of end locations is
+  // -1.
+  const char *query = "AA";
+  const char *target = "B";
+
+  EdlibAlignResult result = edlibAlign(
+      query, static_cast<int>(std::strlen(query)), target,
+      static_cast<int>(std::strlen(target)),
+      edlibNewAlignConfig(-1, EDLIB_MODE_SHW, EDLIB_TASK_PATH, NULL, 0));
+  bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 2;
+  edlibFreeAlignResult(result);
+  EXPECT_TRUE(pass);
+}
+
+TEST(EdlibTest, TestBasic15) {
+  // In this test, optimal alignment is when query and target overlap, query end
+  // with target start, HW.
+  const char *query = "AAABBB";
+  const char *target = "BBBC";
+
+  EdlibAlignResult result = edlibAlign(
+      query, static_cast<int>(std::strlen(query)), target,
+      static_cast<int>(std::strlen(target)),
+      edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_LOC, NULL, 0));
+  bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 3;
+  edlibFreeAlignResult(result);
+  EXPECT_TRUE(pass);
+}
+
+TEST(EdlibTest, TestBasic16) {
+  // In this test, optimal alignment is when query and target overlap, query
+  // start with target end, HW.
+  const char *query = "BBBAAA";
+  const char *target = "CBBB";
+
+  EdlibAlignResult result = edlibAlign(
+      query, static_cast<int>(std::strlen(query)), target,
+      static_cast<int>(std::strlen(target)),
+      edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_LOC, NULL, 0));
+  bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 3;
+  edlibFreeAlignResult(result);
+  EXPECT_TRUE(pass);
+}
+
+TEST(EdlibTest, TestCigar) {
+  unsigned char alignment[] = {
+      EDLIB_EDOP_MATCH,  EDLIB_EDOP_MATCH,  EDLIB_EDOP_INSERT,
+      EDLIB_EDOP_INSERT, EDLIB_EDOP_INSERT, EDLIB_EDOP_DELETE,
+      EDLIB_EDOP_INSERT, EDLIB_EDOP_INSERT, EDLIB_EDOP_MISMATCH,
+      EDLIB_EDOP_MATCH,  EDLIB_EDOP_MATCH};
+  char *cigar = edlibAlignmentToCigar(alignment, 11, EDLIB_CIGAR_EXTENDED);
+  bool pass = true;
+  char expected[] = "2=3I1D2I1X2=";
+  if (strcmp(cigar, expected) != 0) {
+    pass = false;
+    printf("Expected %s, got %s\n", expected, cigar);
+  }
+
+  if (cigar)
+    free(cigar);
+
+  EXPECT_TRUE(pass);
+
+  cigar = edlibAlignmentToCigar(alignment, 11, EDLIB_CIGAR_STANDARD);
+  pass = true;
+  char expected2[] = "2M3I1D2I3M";
+  if (strcmp(cigar, expected2) != 0) {
+    pass = false;
+    printf("Expected %s, got %s\n", expected2, cigar);
+  }
+  if (cigar)
+    free(cigar);
+
+  EXPECT_TRUE(pass);
+}
+
+TEST(EdlibTest, TestCustomEqualityRelation) {
+  EdlibEqualityPair additionalEqualities[6] = {
+      {'R', 'A'}, {'R', 'G'}, {'N', 'A'}, {'N', 'C'}, {'N', 'T'}, {'N', 'G'}};
+
+  const char *query = "GTGNRTCARCGAANCTTTN";
+  const char *target = "GTGAGTCATCGAATCTTTGAACGCACCTTGCGCTCCTTGGT";
+
+  EdlibAlignResult result =
+      edlibAlign(query, 19, target, 41,
+                 edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_PATH,
+                                     additionalEqualities, 6));
+  bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 1;
+  edlibFreeAlignResult(result);
+  EXPECT_TRUE(pass);
+}
+
+TEST(EdlibTest, TestRandom) {
+  srand(42);
+  int numRandomTests = 50;
+  for (auto mode :
+       vector<EdlibAlignMode>{EDLIB_MODE_NW, EDLIB_MODE_HW, EDLIB_MODE_SHW}) {
+    EXPECT_TRUE(runRandomTests(numRandomTests, mode, true));
+    EXPECT_TRUE(runRandomTests(numRandomTests, mode, false));
+  }
+}

--- a/textsearch/csrc/pair_hash.h
+++ b/textsearch/csrc/pair_hash.h
@@ -1,0 +1,52 @@
+// Copied from
+// https://github.com/Martinsos/edlib/blob/gen-seqs/edlib/include/pairHash.hpp
+
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <functional>
+// This header file provides a hashing function for std::pair of any custom
+// types. Since there is no specialization of std::hash for std::pair<T1,T2>
+// provided in the standard library, we can use the implementation in this
+// header file.
+
+/**
+ * Takes a seed and a value of any type. A Seed can be a hash code of other
+ * values or simply 0. It will generate a new hash code using the given seed and
+ * value. It can be called repeatedly to incrementally create a hash value from
+ * several variables. This "magical" implementation is adopted from Boost C++
+ * Libraries.
+ * https://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
+ * @param [in] seed The hash code of previous variables
+ * @param [in] v The value to be hashed using the given seed
+ */
+template <class T> inline void hash_combine(std::size_t &seed, const T &v) {
+  std::hash<T> hasher;
+  seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+template <typename S, typename T> struct pair_hash {
+  inline std::size_t operator()(const std::pair<S, T> &v) const {
+    std::size_t seed = 0;
+    hash_combine(seed, v.first);
+    hash_combine(seed, v.second);
+    return seed;
+  }
+};


### PR DESCRIPTION
This PR tries to template the element type of edlib to make it work for general types, but it seems to have some performance issue for large vocabulary size.

```
char, vocab size : 100
HW: 10/10 random tests passed!
Time Edlib: 0.422493
Time Simple: 4.592351
Times faster: 10.87
HW: 10/10 random tests passed!
Time Edlib: 0.383526
Time Simple: 4.789732
Times faster: 12.49

int16_t, vocab size : 100
HW: 10/10 random tests passed!
Time Edlib: 0.430829
Time Simple: 4.848445
Times faster: 11.25
HW: 10/10 random tests passed!
Time Edlib: 0.372220
Time Simple: 4.484510
Times faster: 12.05

int16_t, vocab size : 10000
HW: 10/10 random tests passed!
Time Edlib: 5.827004
Time Simple: 4.227819
Times faster: 0.73
HW: 10/10 random tests passed!
Time Edlib: 2.175588
Time Simple: 4.317570
Times faster: 1.98

int32_t, vocab size : 100
HW: 10/10 random tests passed!
Time Edlib: 0.422900
Time Simple: 4.700254
Times faster: 11.11
HW: 10/10 random tests passed!
Time Edlib: 0.376183
Time Simple: 4.831155
Times faster: 12.84

int32_t, vocab size : 10000
HW: 10/10 random tests passed!
Time Edlib: 6.304666
Time Simple: 4.472398
Times faster: 0.71
HW: 10/10 random tests passed!
Time Edlib: 2.269119
Time Simple: 4.237992
Times faster: 1.87
```