### PR TITLE
Add Levenshtein distance

### DIFF
--- a/textsearch/csrc/CMakeLists.txt
+++ b/textsearch/csrc/CMakeLists.txt
@@ -18,6 +18,7 @@ endfunction()
 if(FTS_ENABLE_TESTS)
   # please sort the source files alphabetically
   set(test_srcs
+    levenshtein_test.cc
     suffix_array_test.cc
   )
 

--- a/textsearch/csrc/CMakeLists.txt
+++ b/textsearch/csrc/CMakeLists.txt
@@ -13,6 +13,11 @@ function(textsearch_add_test source)
       gtest
       gtest_main
   )
+
+  add_test(NAME "Test.${name}"
+    COMMAND
+    $<TARGET_FILE:${name}>
+  )
 endfunction()
 
 if(FTS_ENABLE_TESTS)

--- a/textsearch/csrc/levenshtein.h
+++ b/textsearch/csrc/levenshtein.h
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <bitset>
+#include <cassert>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -28,6 +29,8 @@
 
 namespace fasttextsearch {
 
+// See docs in Backtrace below, it is a segment of backtrace containing 64 bits
+// of path trace.
 struct DynamicBacktrace {
   int64_t bitmap;
   std::shared_ptr<DynamicBacktrace> prev;
@@ -46,17 +49,13 @@ struct DynamicBacktrace {
 
 struct Backtrace {
   int64_t bitmap; // bitmap records shape of most recent backtrace, where every
-                  // time we consume a query symbol we do: self.bitmap |= (1 <<
+                  // time we consume a query symbol we do: bitmap |= (1 <<
                   // (num_bits++));   and every time we consume a reference
-                  // symbol we do: self.bitmap  |= (0 << (num_bits++));  which
+                  // symbol we do: bitmap  |= (0 << (num_bits++));  which
                   // can be optimized to: num_bits++;  When num_bits reaches 64
                   // we allocate a DynamicBacktrace object and reset it to 0.
   int32_t num_bits;
   std::shared_ptr<DynamicBacktrace> prev;
-
-  Backtrace(int64_t bitmap, int32_t num_bits,
-            std::shared_ptr<DynamicBacktrace> &prev)
-      : bitmap(bitmap), num_bits(num_bits), prev(prev) {}
 
   Backtrace() : bitmap(0), num_bits(0), prev(nullptr){};
 
@@ -66,6 +65,13 @@ struct Backtrace {
   Backtrace(Backtrace &&src) = default;
   Backtrace &operator=(Backtrace &&src) = default;
 
+  /*
+   * Update the Backtrace by increasing the num_bits with 1.
+   *
+   * param [in] update_bitmap If true, bitmap will be updated, it means we are
+   *                          consuming a query symbol. See the docs of bitmap
+   *                          for more details.
+   */
   void Update(bool update_bitmap) {
     if (update_bitmap)
       bitmap |= 1 << num_bits;
@@ -83,6 +89,14 @@ struct Backtrace {
     }
   }
 
+  /*
+   * Convert the bitmap backtrace to string (i.e. the bit string like '011001').
+   *
+   * Note: In the original bitmap the latest bits are on the left side (because
+   * we update bitmap with `bitmap |= 1 << num_bits`), but in the return string
+   * the latest bits are on the right side. For example, the original bitmap is
+   * `0b110110`, the returned string will be `011011`.
+   */
   std::string ToString() const {
     std::ostringstream oss;
     if (num_bits != 0) {
@@ -100,10 +114,17 @@ struct Backtrace {
   }
 };
 
+/*
+ * The class represents the internal state of levenshtein dp recursion
+ * containing the cost up to now and the backtrace.
+ */
 struct LevenshteinElement {
-  int32_t cost;
-  int64_t position;
-  Backtrace backtrace;
+  int32_t cost; // The cost (levenshtein distance) up to current element
+  int64_t
+      position; // The index into the target array indicating the position of
+                // the target where this element comes from. This will be useful
+                // when recovering the alignment between query and target.
+  Backtrace backtrace; // The backtrace from which we can recover the alignment.
 
   explicit LevenshteinElement(int32_t cost) : cost(cost) {}
 
@@ -118,33 +139,97 @@ struct LevenshteinElement {
   LevenshteinElement(LevenshteinElement &&src) = default;
   LevenshteinElement &operator=(LevenshteinElement &&src) = default;
 
+  /*
+   * Handle deletion error given current element.
+   *
+   * @param [in] c The deletion cost.
+   *
+   * @return Return a new LevenshteinElement object with cost and
+   *         backtrace updated based on current element.
+   */
   LevenshteinElement Delete(int32_t c) const {
     auto res = LevenshteinElement(cost + c, backtrace);
-    res.backtrace.Update(false);
+    res.backtrace.Update(false); // consuming target symbol
     return res;
   }
 
+  /*
+   * Handle insertion error given current element.
+   *
+   * @param [in] c The insertion cost.
+   *
+   * @return Return a new LevenshteinElement object with cost and
+   *         backtrace updated based on current element.
+   */
   LevenshteinElement Insert(int32_t c) const {
     auto res = LevenshteinElement(cost + c, backtrace);
-    res.backtrace.Update(true);
+    res.backtrace.Update(true); // consuming query symbol
     return res;
   }
 
+  /*
+   * Handle replacement error given current element.
+   *
+   * @param [in] c The replacement cost.
+   *
+   * @return Return a new LevenshteinElement object with cost and
+   *         backtrace updated based on current element.
+   */
   LevenshteinElement Replace(int32_t c) const {
     auto res = LevenshteinElement(cost + c, backtrace);
+    // Consuming both query and target symbols
+    // Caution: DO NOT change the order of following two lines, it determines
+    // how we recover the alignment.
     res.backtrace.Update(false);
     res.backtrace.Update(true);
     return res;
   }
 
+  /*
+   * Handle equal given current element.
+   *
+   * Note: Only the backtrace will be updated.
+   *
+   * @return Return a new LevenshteinElement object with
+   *         backtrace updated based on current element.
+   */
   LevenshteinElement Equal() const {
     auto res = LevenshteinElement(cost, backtrace);
+    // Consuming both query and target symbols
+    // Caution: DO NOT change the order of following two lines, it determines
+    // how we recover the alignment.
     res.backtrace.Update(false);
     res.backtrace.Update(true);
     return res;
   }
 };
 
+/*
+ * Calculate the levenshtein distance between query and target and also return
+ * the alignments (can be constructed from backtrace in LevenshteinElement).
+ *
+ * Note: We are doing the infix search, gaps at query end and start are not
+ * penalized. What that means is that deleting elements from the start and end
+ * of target is "free"! For example, if we had ACT and CGACTGAC, the levenshtein
+ * distance would be 0, because removing CG from the start and GAC from the end
+ * of target is "free" and does not count into total levenshtein distance.
+ *
+ * @param [in] query The pointer to the query sequence.
+ * @param [in] query_length The length of the query sequence.
+ * @param [in] target The pointer to the target sequence.
+ * @param [in] target_length The length of the target sequence.
+ * @param [in,out] alignments  The container that alignments info will write to.
+ *                             Because we are doing infix search, so there might
+ *                             be multiple matches in target sequence with the
+ *                             same levenshtein distance. `alignments` will be
+ *                             reallocated in this function, it's size will be
+ *                             the number of matching segments.
+ * @param [in] insert_cost  The cost of insertion.
+ * @param [in] delete_cost  The cost of deletion.
+ * @param [in] replace_cost  The cost of replacement.
+ *
+ * @return  Returns the levenshtein distance between query and target.
+ */
 template <typename T>
 int32_t LevenshteinDistance(const T *query, size_t query_length,
                             const T *target, size_t target_length,
@@ -154,10 +239,9 @@ int32_t LevenshteinDistance(const T *query, size_t query_length,
 
   LevenshteinElement best_score = LevenshteinElement(-1);
 
-  // TODO(WeiKang) Handle edge cases
-  if (query_length == 0 || target_length == 0) {
-    assert(false);
-    return query_length;
+  assert(target_length != 0);
+  if (query_length == 0) {
+    return 0;
   }
 
   auto scores = std::vector<LevenshteinElement>(query_length + 1);
@@ -170,7 +254,8 @@ int32_t LevenshteinDistance(const T *query, size_t query_length,
   for (size_t j = 1; j <= target_length; j++) {
     LevenshteinElement prev_diag = scores[0], prev_diag_cache;
 
-    // infix search
+    // we are doing infix search, the cost of the beginning symbol will always
+    // be 0.
     scores[0] = LevenshteinElement(0);
 
     for (size_t k = 1; k <= query_length; k++) {

--- a/textsearch/csrc/levenshtein.h
+++ b/textsearch/csrc/levenshtein.h
@@ -1,0 +1,208 @@
+/**
+ * Copyright      2023     Xiaomi Corporation (authors: Wei Kang)
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TEXTSEARCH_CSRC_LEVENSHTEIN_H_
+#define TEXTSEARCH_CSRC_LEVENSHTEIN_H_
+
+#include <algorithm>
+#include <bitset>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace fasttextsearch {
+
+struct DynamicBacktrace {
+  int64_t bitmap;
+  std::shared_ptr<DynamicBacktrace> prev;
+
+  DynamicBacktrace(int64_t bitmap, std::shared_ptr<DynamicBacktrace> prev)
+      : bitmap(bitmap), prev(prev) {}
+
+  explicit DynamicBacktrace(int64_t bitmap) : bitmap(bitmap) {}
+
+  DynamicBacktrace &operator=(const DynamicBacktrace &src) = default;
+  DynamicBacktrace(const DynamicBacktrace &src) = default;
+  // Move constructor
+  DynamicBacktrace(DynamicBacktrace &&src) = default;
+  DynamicBacktrace &operator=(DynamicBacktrace &&src) = default;
+};
+
+struct Backtrace {
+  int64_t bitmap; // bitmap records shape of most recent backtrace, where every
+                  // time we consume a query symbol we do: self.bitmap |= (1 <<
+                  // (num_bits++));   and every time we consume a reference
+                  // symbol we do: self.bitmap  |= (0 << (num_bits++));  which
+                  // can be optimized to: num_bits++;  When num_bits reaches 64
+                  // we allocate a DynamicBacktrace object and reset it to 0.
+  int32_t num_bits;
+  std::shared_ptr<DynamicBacktrace> prev;
+
+  Backtrace(int64_t bitmap, int32_t num_bits,
+            std::shared_ptr<DynamicBacktrace> &prev)
+      : bitmap(bitmap), num_bits(num_bits), prev(prev) {}
+
+  Backtrace() : bitmap(0), num_bits(0), prev(nullptr){};
+
+  Backtrace &operator=(const Backtrace &src) = default;
+  Backtrace(const Backtrace &src) = default;
+  // Move constructor
+  Backtrace(Backtrace &&src) = default;
+  Backtrace &operator=(Backtrace &&src) = default;
+
+  void Update(bool update_bitmap) {
+    if (update_bitmap)
+      bitmap |= 1 << num_bits;
+
+    num_bits++;
+
+    if (num_bits == 64) {
+      if (prev == nullptr) {
+        prev = std::make_shared<DynamicBacktrace>(bitmap);
+      } else {
+        prev = std::make_shared<DynamicBacktrace>(bitmap, prev->prev);
+      }
+      bitmap = 0;
+      num_bits = 0;
+    }
+  }
+
+  std::string ToString() const {
+    std::ostringstream oss;
+    if (num_bits != 0) {
+      auto str = std::bitset<64>(bitmap).to_string().substr(64 - num_bits);
+      oss << str.substr(0, num_bits);
+    }
+    auto trace = prev;
+    while (trace != nullptr) {
+      oss << std::bitset<64>(trace->bitmap);
+      trace = trace->prev;
+    }
+    auto str = oss.str();
+    std::reverse(str.begin(), str.end());
+    return str;
+  }
+};
+
+struct LevenshteinElement {
+  int32_t cost;
+  int64_t position;
+  Backtrace backtrace;
+
+  explicit LevenshteinElement(int32_t cost) : cost(cost) {}
+
+  LevenshteinElement(int32_t cost, Backtrace backtrace)
+      : cost(cost), backtrace(backtrace) {}
+
+  LevenshteinElement() = default;
+
+  LevenshteinElement &operator=(const LevenshteinElement &src) = default;
+  LevenshteinElement(const LevenshteinElement &src) = default;
+  // Move constructor
+  LevenshteinElement(LevenshteinElement &&src) = default;
+  LevenshteinElement &operator=(LevenshteinElement &&src) = default;
+
+  LevenshteinElement Delete(int32_t c) const {
+    auto res = LevenshteinElement(cost + c, backtrace);
+    res.backtrace.Update(false);
+    return res;
+  }
+
+  LevenshteinElement Insert(int32_t c) const {
+    auto res = LevenshteinElement(cost + c, backtrace);
+    res.backtrace.Update(true);
+    return res;
+  }
+
+  LevenshteinElement Replace(int32_t c) const {
+    auto res = LevenshteinElement(cost + c, backtrace);
+    res.backtrace.Update(false);
+    res.backtrace.Update(true);
+    return res;
+  }
+
+  LevenshteinElement Equal() const {
+    auto res = LevenshteinElement(cost, backtrace);
+    res.backtrace.Update(false);
+    res.backtrace.Update(true);
+    return res;
+  }
+};
+
+template <typename T>
+int32_t LevenshteinDistance(const T *query, size_t query_length,
+                            const T *target, size_t target_length,
+                            std::vector<LevenshteinElement> *alignments,
+                            int32_t insert_cost = 1, int32_t delete_cost = 1,
+                            int32_t replace_cost = 1) {
+
+  LevenshteinElement best_score = LevenshteinElement(-1);
+
+  // TODO(WeiKang) Handle edge cases
+  if (query_length == 0 || target_length == 0) {
+    assert(false);
+    return query_length;
+  }
+
+  auto scores = std::vector<LevenshteinElement>(query_length + 1);
+
+  scores[0] = LevenshteinElement(0);
+  for (size_t i = 1; i <= query_length; i++) {
+    scores[i] = scores[i - 1].Insert(insert_cost);
+  }
+
+  for (size_t j = 1; j <= target_length; j++) {
+    LevenshteinElement prev_diag = scores[0], prev_diag_cache;
+
+    // infix search
+    scores[0] = LevenshteinElement(0);
+
+    for (size_t k = 1; k <= query_length; k++) {
+      prev_diag_cache = scores[k];
+      if (query[k - 1] == target[j - 1]) {
+        scores[k] = prev_diag.Equal(); // equal
+      } else {
+        if (scores[k].cost <= scores[k - 1].cost &&
+            scores[k].cost <= prev_diag.cost) { // deletion
+          scores[k] = scores[k].Delete(delete_cost);
+        } else if (scores[k - 1].cost <= scores[k].cost &&
+                   scores[k - 1].cost <= prev_diag.cost) { // insertion
+          scores[k] = scores[k - 1].Insert(insert_cost);
+        } else { // replacement
+          scores[k] = prev_diag.Replace(replace_cost);
+        }
+      }
+      prev_diag = prev_diag_cache;
+    }
+
+    auto score = scores[query_length];
+    if (best_score.cost == -1 || score.cost <= best_score.cost) {
+      if (score.cost < best_score.cost) {
+        alignments->clear();
+      }
+      best_score = score;
+      score.position = j - 1;
+      alignments->push_back(score);
+    }
+  }
+  return best_score.cost;
+}
+} // namespace fasttextsearch
+
+#endif // TEXTSEARCH_CSRC_LEVENSHTEIN_H_

--- a/textsearch/csrc/levenshtein_test.cc
+++ b/textsearch/csrc/levenshtein_test.cc
@@ -1,0 +1,50 @@
+/**
+ * Copyright      2023     Xiaomi Corporation (authors: Wei Kang)
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <vector>
+
+#include "textsearch/csrc/levenshtein.h"
+
+namespace fasttextsearch {
+
+TEST(Levenshtein, TestBasic) {
+  auto query = std::vector<int32_t>({1, 3, 4, 5, 6, 7, 8, 9});
+  auto target = std::vector<int32_t>({1, 4, 5, 3, 7, 8, 9, 5, 3, 6, 3, 4, 5, 6,
+                                      7, 8, 2, 3, 5, 1, 2, 3, 4, 5, 6, 7, 8});
+
+  std::vector<LevenshteinElement> alignments;
+  auto result = LevenshteinDistance(query.data(), query.size(), target.data(),
+                                    target.size(), &alignments);
+
+  EXPECT_EQ(result, 2);
+  EXPECT_EQ(alignments.size(), 4);
+  auto expected_position = std::vector<int32_t>({6, 15, 16, 26});
+  auto expected_trace =
+      std::vector<std::string>({"011010101010101", "10101010101011",
+                                "101010101010101", "0100101010101011"});
+  for (size_t i = 0; i < alignments.size(); ++i) {
+    auto align = alignments[i];
+    EXPECT_EQ(align.cost, 2);
+    EXPECT_EQ(align.position, expected_position[i]);
+    EXPECT_EQ(align.backtrace.ToString(), expected_trace[i]);
+  }
+}
+} // namespace fasttextsearch

--- a/textsearch/python/csrc/CMakeLists.txt
+++ b/textsearch/python/csrc/CMakeLists.txt
@@ -1,4 +1,5 @@
 pybind11_add_module(_fasttextsearch
+  levenshtein.cc
   suffix_array.cc
   text_search.cc
 )

--- a/textsearch/python/csrc/levenshtein.cc
+++ b/textsearch/python/csrc/levenshtein.cc
@@ -57,8 +57,29 @@ PybindLevenshteinHelper(py::array_t<T, py::array::c_style> &query,
   return std::make_pair(distance, trace);
 }
 
+static std::pair<int32_t, std::vector<std::pair<int64_t, std::string>>>
+PybindStringLevenshteinHelper(const std::string &query,
+                              const std::string &target, int32_t insert_cost,
+                              int32_t delete_cost, int32_t replace_cost) {
+  std::vector<LevenshteinElement> alignments;
+
+  int32_t distance = LevenshteinDistance(
+      query.data(), query.size(), target.data(), target.size(), &alignments,
+      insert_cost, delete_cost, replace_cost);
+
+  std::vector<std::pair<int64_t, std::string>> trace;
+  for (const auto align : alignments) {
+    trace.push_back(std::make_pair(align.position, align.backtrace.ToString()));
+  }
+
+  return std::make_pair(distance, trace);
+}
+
 void PybindLevenshtein(py::module &m) {
   m.def("levenshtein_distance", &PybindLevenshteinHelper<int32_t>,
+        py::arg("query"), py::arg("target"), py::arg("insert_cost") = 1,
+        py::arg("delete_cost") = 1, py::arg("replace_cost") = 1);
+  m.def("levenshtein_distance", &PybindStringLevenshteinHelper,
         py::arg("query"), py::arg("target"), py::arg("insert_cost") = 1,
         py::arg("delete_cost") = 1, py::arg("replace_cost") = 1);
 }

--- a/textsearch/python/csrc/levenshtein.cc
+++ b/textsearch/python/csrc/levenshtein.cc
@@ -25,6 +25,58 @@
 
 namespace fasttextsearch {
 
+static constexpr const char *kLevenshteinDistanceDoc = R"doc(
+Calculate the levenshtein distance between query and target sequence.
+
+Note:
+  We are doing the infix search, gaps at query end and start are not
+  penalized. What that means is that deleting elements from the start and end
+  of target is "free"! For example, if we had ACT and CGACTGAC, the levenshtein
+  distance would be 0, because removing CG from the start and GAC from the end
+  of target is "free" and does not count into total levenshtein distance.
+
+Args:
+  query:
+    The query sequence, it is a one dimension numpy ndarray, only np.int32 is
+    supported now.
+  target:
+    The target sequence, it is a one dimension numpy ndarray with same dtype as
+    query sequence.
+  insert_cost:
+    The cost of insertion error, default 1.
+  delete_cost:
+    The cost of deletion error, default 1.
+  replace_cost:
+    The cost of replacement error, default 1.
+
+Returns:
+  Return a tuple which has two elements, the first element is the levenshtein
+  distance, the second element is a list of tuple, each tuple in the list has
+  `end_position` (index into the target sequence) and `alignment`
+  (`0,1` string containing the backtrace). See the examples below for more
+  details.
+
+>>> from textsearch import levenshtein_distance
+>>> import numpy as np
+>>> query = np.array([1, 2, 3, 4], dtype=np.int32)
+>>> target = np.array([1, 5, 3, 4, 6, 7, 1, 2, 4], dtype=np.int32)
+>>> distance, alignments = levenshtein_distance(query, target)
+>>> print (distance, alignments)
+1 [(3, '01010101'), (8, '0101101')]
+
+The result above indicates that there are two segments in target sequence have the
+same levenshtein distance with query sequence. The levenshtein distance is 1,
+the end index of first segment into target sequence is 3 ([1,5,3,4]), and the
+end index of second sequence is 8 ([1,2,4]). For the backtrace string, '1' means
+consuming a query symbol, '0' means consuming a target symbol, we can interpret
+the backtrace string like this, from the ending to the beginning, if we meet a
+'1' followed by a '0', it means equal or replacement (consuming both query
+target); if we meet a '1', it means insertion; if we meet a '0', it means
+deletion. So the alignment of first segment is [euqal, replacement, equal, equal],
+the alignment of the second segment is [equal, equal, insertion, equal]. We can
+distinct equal and replacement with the help of query and target sequences.
+)doc";
+
 template <typename T>
 static std::pair<int32_t, std::vector<std::pair<int64_t, std::string>>>
 PybindLevenshteinHelper(py::array_t<T, py::array::c_style> &query,
@@ -60,6 +112,7 @@ PybindLevenshteinHelper(py::array_t<T, py::array::c_style> &query,
 void PybindLevenshtein(py::module &m) {
   m.def("levenshtein_distance", &PybindLevenshteinHelper<int32_t>,
         py::arg("query"), py::arg("target"), py::arg("insert_cost") = 1,
-        py::arg("delete_cost") = 1, py::arg("replace_cost") = 1);
+        py::arg("delete_cost") = 1, py::arg("replace_cost") = 1,
+        kLevenshteinDistanceDoc);
 }
 } // namespace fasttextsearch

--- a/textsearch/python/csrc/levenshtein.cc
+++ b/textsearch/python/csrc/levenshtein.cc
@@ -57,29 +57,8 @@ PybindLevenshteinHelper(py::array_t<T, py::array::c_style> &query,
   return std::make_pair(distance, trace);
 }
 
-static std::pair<int32_t, std::vector<std::pair<int64_t, std::string>>>
-PybindStringLevenshteinHelper(const std::string &query,
-                              const std::string &target, int32_t insert_cost,
-                              int32_t delete_cost, int32_t replace_cost) {
-  std::vector<LevenshteinElement> alignments;
-
-  int32_t distance = LevenshteinDistance(
-      query.data(), query.size(), target.data(), target.size(), &alignments,
-      insert_cost, delete_cost, replace_cost);
-
-  std::vector<std::pair<int64_t, std::string>> trace;
-  for (const auto align : alignments) {
-    trace.push_back(std::make_pair(align.position, align.backtrace.ToString()));
-  }
-
-  return std::make_pair(distance, trace);
-}
-
 void PybindLevenshtein(py::module &m) {
   m.def("levenshtein_distance", &PybindLevenshteinHelper<int32_t>,
-        py::arg("query"), py::arg("target"), py::arg("insert_cost") = 1,
-        py::arg("delete_cost") = 1, py::arg("replace_cost") = 1);
-  m.def("levenshtein_distance", &PybindStringLevenshteinHelper,
         py::arg("query"), py::arg("target"), py::arg("insert_cost") = 1,
         py::arg("delete_cost") = 1, py::arg("replace_cost") = 1);
 }

--- a/textsearch/python/csrc/levenshtein.cc
+++ b/textsearch/python/csrc/levenshtein.cc
@@ -1,0 +1,65 @@
+/**
+ * Copyright      2023     Xiaomi Corporation (authors: Wei Kang)
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "textsearch/python/csrc/levenshtein.h"
+#include "pybind11/numpy.h"
+#include "pybind11/stl.h"
+#include "textsearch/csrc/levenshtein.h"
+#include <iostream>
+#include <limits>
+
+namespace fasttextsearch {
+
+template <typename T>
+static std::pair<int32_t, std::vector<std::pair<int64_t, std::string>>>
+PybindLevenshteinHelper(py::array_t<T, py::array::c_style> &query,
+                        py::array_t<T, py::array::c_style> &target,
+                        int32_t insert_cost, int32_t delete_cost,
+                        int32_t replace_cost) {
+
+  py::buffer_info query_buf = query.request();
+  py::buffer_info target_buf = target.request();
+
+  if (query_buf.ndim != 1)
+    throw std::runtime_error("Query MUST be a one dimension array");
+  if (target_buf.ndim != 1)
+    throw std::runtime_error("Target MUST be a one dimension array");
+
+  T *query_data = static_cast<T *>(query_buf.ptr);
+  T *target_data = static_cast<T *>(target_buf.ptr);
+
+  std::vector<LevenshteinElement> alignments;
+
+  int32_t distance = LevenshteinDistance(
+      query_data, query_buf.size, target_data, target_buf.size, &alignments,
+      insert_cost, delete_cost, replace_cost);
+
+  std::vector<std::pair<int64_t, std::string>> trace;
+  for (const auto align : alignments) {
+    trace.push_back(std::make_pair(align.position, align.backtrace.ToString()));
+  }
+
+  return std::make_pair(distance, trace);
+}
+
+void PybindLevenshtein(py::module &m) {
+  m.def("levenshtein_distance", &PybindLevenshteinHelper<int32_t>,
+        py::arg("query"), py::arg("target"), py::arg("insert_cost") = 1,
+        py::arg("delete_cost") = 1, py::arg("replace_cost") = 1);
+}
+} // namespace fasttextsearch

--- a/textsearch/python/csrc/levenshtein.h
+++ b/textsearch/python/csrc/levenshtein.h
@@ -16,15 +16,15 @@
  * limitations under the License.
  */
 
-#ifndef TEXTSEARCH_PYTHON_CSRC_SUFFIX_ARRAY_H_
-#define TEXTSEARCH_PYTHON_CSRC_SUFFIX_ARRAY_H_
+#ifndef TEXTSEARCH_PYTHON_CSRC_LEVENSHTEIN_H_
+#define TEXTSEARCH_PYTHON_CSRC_LEVENSHTEIN_H_
 
 #include "textsearch/python/csrc/text_search.h"
 
 namespace fasttextsearch {
 
-void PybindSuffixArray(py::module &m);
+void PybindLevenshtein(py::module &m);
 
 } // namespace fasttextsearch
 
-#endif // TEXTSEARCH_PYTHON_CSRC_SUFFIX_ARRAY_H_
+#endif // TEXTSEARCH_PYTHON_CSRC_LEVENSHTEIN_H_

--- a/textsearch/python/csrc/suffix_array.cc
+++ b/textsearch/python/csrc/suffix_array.cc
@@ -1,6 +1,20 @@
-// textsearch/python/csrc/suffix_array.cc
-//
-// Copyright (c)  2023  Xiaomi Corporation (authors: Wei Kang)
+/**
+ * Copyright      2023     Xiaomi Corporation (authors: Wei Kang)
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "textsearch/python/csrc/suffix_array.h"
 #include "pybind11/numpy.h"

--- a/textsearch/python/csrc/text_search.cc
+++ b/textsearch/python/csrc/text_search.cc
@@ -4,6 +4,7 @@
 
 #include "textsearch/python/csrc/text_search.h"
 
+#include "textsearch/python/csrc/levenshtein.h"
 #include "textsearch/python/csrc/suffix_array.h"
 
 namespace fasttextsearch {
@@ -11,6 +12,7 @@ namespace fasttextsearch {
 PYBIND11_MODULE(_fasttextsearch, m) {
   m.doc() = "Python wrapper for textsearch";
 
+  PybindLevenshtein(m);
   PybindSuffixArray(m);
 }
 

--- a/textsearch/python/tests/CMakeLists.txt
+++ b/textsearch/python/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ endfunction()
 
 if(FTS_ENABLE_TESTS)
   set(test_srcs
+    test_levenshtein_distance.py
     test_suffix_array.py
   )
 

--- a/textsearch/python/tests/test_levenshtein_distance.py
+++ b/textsearch/python/tests/test_levenshtein_distance.py
@@ -23,7 +23,7 @@
 import unittest
 import numpy as np
 
-from textsearch import levenshtein_distance, get_nice_alignments
+from textsearch import get_nice_alignments, levenshtein_distance
 
 
 class TestLevenshtein(unittest.TestCase):

--- a/textsearch/python/tests/test_levenshtein_distance.py
+++ b/textsearch/python/tests/test_levenshtein_distance.py
@@ -23,34 +23,29 @@
 import unittest
 import numpy as np
 
-from textsearch import levenshtein_distance
+from textsearch import levenshtein_distance, get_nice_alignments
 
 
 class TestLevenshtein(unittest.TestCase):
     def test_levenshtein_distance(self):
-        query = np.array([1,2,3,4], dtype=np.int32)
-        target = np.array([1,5,3,4,6,7,1,2,4], dtype=np.int32)
+        query = np.array([1, 2, 3, 4], dtype=np.int32)
+        target = np.array([1, 5, 3, 4, 6, 7, 1, 2, 4], dtype=np.int32)
         distance, alignments = levenshtein_distance(query, target)
         self.assertTrue(distance == 1)
         self.assertTrue(len(alignments) == 2)
-        self.assertTrue(alignments[0] == (3, '01010101'))
-        self.assertTrue(alignments[1] == (8, '0101101'))
+        self.assertTrue(alignments[0] == (3, "01010101"))
+        self.assertTrue(alignments[1] == (8, "0101101"))
 
-    def test_levenshtein_distance_string(self):
-        query = "hello"
-        target = "hellaworldgellop"
+    def test_get_nice_alignments(self):
+        query = np.array([10, 234, 98745, 14, 8], dtype=np.int32)
+        target = np.array([7, 10, 134, 9, 98745, 8], dtype=np.int32)
         distance, alignments = levenshtein_distance(query, target)
-        self.assertTrue(distance == 1)
-        self.assertTrue(len(alignments) == 3)
-        self.assertTrue(alignments[0] == (3, '010101011'))
-        self.assertTrue(alignments[1] == (4, '0101010101'))
-        self.assertTrue(alignments[2] == (14, '101010101'))
-
-        query = "我爱中国"
-        target = "我喜中国他也爱中国我爱美国"
-        distance, alignments = levenshtein_distance(query, target)
-        print (distance, alignments)
-
+        align_str = get_nice_alignments(alignments, query, target)
+        expected_align = (
+            "10 234 * 98745 14 8 \n|  #   - |     +  | \n10 134 9 98745 *  8 "
+        )
+        self.assertTrue(len(align_str) == 1)
+        self.assertTrue(align_str[0] == expected_align)
 
 
 if __name__ == "__main__":

--- a/textsearch/python/tests/test_levenshtein_distance.py
+++ b/textsearch/python/tests/test_levenshtein_distance.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+#
+# Copyright      2023  Xiaomi Corp.       (authors: Wei Kang)
+#
+# See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To run this single test, use
+#
+#  ctest --verbose -R levenshtein_distance_test_py
+
+import unittest
+import numpy as np
+
+from textsearch import levenshtein_distance
+
+
+class TestLevenshtein(unittest.TestCase):
+    def test_levenshtein_distance(self):
+        query = np.array([1,2,3,4], dtype=np.int32)
+        target = np.array([1,5,3,4,6,7,1,2,4], dtype=np.int32)
+        distance, alignments = levenshtein_distance(query, target)
+        self.assertTrue(distance == 1)
+        self.assertTrue(alignments[0] == (3, '01010101'))
+        self.assertTrue(alignments[1] == (8, '0101101'))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/textsearch/python/tests/test_levenshtein_distance.py
+++ b/textsearch/python/tests/test_levenshtein_distance.py
@@ -32,8 +32,26 @@ class TestLevenshtein(unittest.TestCase):
         target = np.array([1,5,3,4,6,7,1,2,4], dtype=np.int32)
         distance, alignments = levenshtein_distance(query, target)
         self.assertTrue(distance == 1)
+        self.assertTrue(len(alignments) == 2)
         self.assertTrue(alignments[0] == (3, '01010101'))
         self.assertTrue(alignments[1] == (8, '0101101'))
+
+    def test_levenshtein_distance_string(self):
+        query = "hello"
+        target = "hellaworldgellop"
+        distance, alignments = levenshtein_distance(query, target)
+        self.assertTrue(distance == 1)
+        self.assertTrue(len(alignments) == 3)
+        self.assertTrue(alignments[0] == (3, '010101011'))
+        self.assertTrue(alignments[1] == (4, '0101010101'))
+        self.assertTrue(alignments[2] == (14, '101010101'))
+
+        query = "我爱中国"
+        target = "我喜中国他也爱中国我爱美国"
+        distance, alignments = levenshtein_distance(query, target)
+        print (distance, alignments)
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/textsearch/python/tests/test_suffix_array.py
+++ b/textsearch/python/tests/test_suffix_array.py
@@ -18,7 +18,7 @@
 
 # To run this single test, use
 #
-#  ctest --verbose -R cat_test_py
+#  ctest --verbose -R suffix_array_test_py
 
 import unittest
 import numpy as np

--- a/textsearch/python/textsearch/__init__.py
+++ b/textsearch/python/textsearch/__init__.py
@@ -1,2 +1,3 @@
+from _fasttextsearch import levenshtein_distance
 from .suffix_array import create_suffix_array
 from .suffix_array import find_close_matches

--- a/textsearch/python/textsearch/__init__.py
+++ b/textsearch/python/textsearch/__init__.py
@@ -1,3 +1,4 @@
 from _fasttextsearch import levenshtein_distance
+from .levenshtein import get_nice_alignments
 from .suffix_array import create_suffix_array
 from .suffix_array import find_close_matches

--- a/textsearch/python/textsearch/levenshtein.py
+++ b/textsearch/python/textsearch/levenshtein.py
@@ -21,6 +21,39 @@ from typing import List, Tuple
 def get_nice_alignments(
     alignments: List[Tuple[int, str]], query: np.ndarray, target: np.ndarray
 ) -> List[str]:
+    """
+    Get the alignment of the matched segments.
+
+    Args:
+      alignments:
+        The alignments information returned by the `levenshtein_distance`.
+      query:
+        The query sequence.
+      target:
+        The target sequence.
+
+    Returns:
+      Return a list of alignment string, it has the same length as alignments.
+      See the following example for more details, the first line of the alignment
+      is query, the second line is the error types, the third line is the target
+      segment. '*' means empty, '+' means insertion, '-' means deletion, '#' means
+      replacement, '|' means equal.
+
+    >>> from textsearch import get_nice_alignments, levenshtein_distance
+    >>> import numpy as np
+    >>> query = np.array([1, 2, 3, 4], dtype=np.int32)
+    >>> target = np.array([1, 5, 3, 4, 6, 7, 1, 2, 4], dtype=np.int32)
+    >>> distance, alignments = levenshtein_distance(query, target)
+    >>> aligns = get_nice_alignments(alignments, a, b)
+    >>> print (aligns[0])
+    1 2 3 4
+    | # | |
+    1 5 3 4
+    >>> print (aligns[1])
+    1 2 3 4
+    | | + |
+    1 2 * 4
+    """
     results = []
     for align in alignments:
         j = align[0]

--- a/textsearch/python/textsearch/levenshtein.py
+++ b/textsearch/python/textsearch/levenshtein.py
@@ -1,0 +1,84 @@
+# Copyright      2023   Xiaomi Corp.       (author: Wei Kang)
+#
+# See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from typing import List, Tuple
+
+
+def get_nice_alignments(
+    alignments: List[Tuple[int, str]], query: np.ndarray, target: np.ndarray
+) -> List[str]:
+    results = []
+    for align in alignments:
+        j = align[0]
+        i = len(query) - 1
+        k = len(align[1]) - 1
+        qs = ""
+        ms = ""
+        ts = ""
+        while k - 1 >= 0:
+            if align[1][k] == "0":
+                ts_ = f"{target[j]} "
+                sl = len(ts_)
+
+                qs += f"{'*':>{sl}}"
+                ms += f"{'-':>{sl}}"
+                ts += f"{ts_[::-1]:>{sl}}"
+                j = j - 1
+                k = k - 1
+            elif align[1][k] == "1" and align[1][k - 1] == "0":
+                qs_ = f"{query[i]} "
+                ts_ = f"{target[j]} "
+                sl = max(len(qs_), len(ts_))
+
+                qs += f"{qs_[::-1]:>{sl}}"
+                ts += f"{ts_[::-1]:>{sl}}"
+                if query[i] == target[j]:
+                    ms += f"{'|':>{sl}}"
+                else:
+                    ms += f"{'#':>{sl}}"
+                j = j - 1
+                i = i - 1
+                k = k - 2
+            else:
+                assert align[1][k] == "1", align[1][k]
+                qs_ = f"{query[i]} "
+                sl = len(qs_)
+
+                qs += f"{qs_[::-1]:>{sl}}"
+                ms += f"{'+':>{sl}}"
+                ts += f"{'*':>{sl}}"
+                i = i - 1
+                k = k - 1
+        if k > 0:
+            assert k == 1, k
+            if align[1][k] == "0":
+                ts_ = f"{target[j]} "
+                sl = len(ts_)
+
+                qs += f"{'*':>{sl}}"
+                ms += f"{'-':>{sl}}"
+                ts += f"{ts_[::-1]:>{sl}}"
+            else:
+                assert align[1][k] == "1", align[1][k]
+                qs_ = f"{query[i]} "
+                sl = len(qs_)
+
+                qs += f"{qs_[::-1]:>{sl}}"
+                ms += f"{'+':>{sl}}"
+                ts += f"{'*':>{sl}}"
+        results.append("\n".join([qs[::-1], ms[::-1], ts[::-1]]))
+    return results


### PR DESCRIPTION
Implements the ideas in https://github.com/danpovey/text_search/pull/10#issuecomment-1442820456

```python
from textsearch import get_nice_alignments, levenshtein_distance
import numpy as np

query = np.array([1, 2, 3, 4, 20, 13], dtype=np.int32)
target = np.array([1, 5, 3, 4, 20, 6, 7, 1, 2, 4, 20, 21, 13], dtype=np.int32)
distance, alignments = levenshtein_distance(query, target)
print (distance, alignments)
aligns = get_nice_alignments(alignments, query, target)
for align in aligns:
    print (align)
    print ("\n")
```
```
2 [(4, '01010101011'), (5, '010101010101'), (10, '0101101011'), (11, '01011010101'), (12, '010110101001')]
1 2 3 4 20 13
| # | | |  +
1 5 3 4 20 *


1 2 3 4 20 13
| # | | |  #
1 5 3 4 20 6


1 2 3 4 20 13
| | + | |  +
1 2 * 4 20 *


1 2 3 4 20 13
| | + | |  #
1 2 * 4 20 21


1 2 3 4 20 *  13
| | + | |  -  |
1 2 * 4 20 21 13
```