### PR TITLE
Add New2old function

### DIFF
--- a/textsearch/csrc/utils.cc
+++ b/textsearch/csrc/utils.cc
@@ -52,8 +52,7 @@ void GetNew2Old(const bool *keep, size_t num_old_elems,
     if (i == old2new.size() - 1 || old2new[i + 1] > old2new[i])
       (*new2old)[old2new[i]] = i;
   }
-  *new2old = std::vector<uint64_t>(new2old->begin(),
-                                   new2old->begin() + new2old->size() - 1);
+  new2old->resize(num_new_elems);
 }
 
 } // namespace fasttextsearch

--- a/textsearch/csrc/utils.cc
+++ b/textsearch/csrc/utils.cc
@@ -32,22 +32,22 @@ void RowIdsToRowSplits(int32_t num_elems, const uint32_t *row_ids,
   }
 }
 
-void GetNew2Old(const bool *keep, size_t num_old_elems,
-                std::vector<uint64_t> *new2old) {
-  auto old2new = std::vector<uint64_t>(num_old_elems);
+void GetNew2Old(const bool *keep, uint32_t num_old_elems,
+                std::vector<uint32_t> *new2old) {
+  auto old2new = std::vector<uint32_t>(num_old_elems);
 
   // Exclusive sum
-  uint64_t sum = 0;
+  uint32_t sum = 0;
   for (size_t i = 0; i != old2new.size(); ++i) {
     old2new[i] = sum;
     sum += (int)keep[i];
   }
-  uint64_t num_new_elems = sum;
+  uint32_t num_new_elems = sum;
 
   assert(num_new_elems >= 0);
   assert(num_new_elems <= num_old_elems);
 
-  *new2old = std::vector<uint64_t>(num_new_elems + 1);
+  *new2old = std::vector<uint32_t>(num_new_elems + 1);
   for (size_t i = 0; i != old2new.size(); ++i) {
     if (i == old2new.size() - 1 || old2new[i + 1] > old2new[i])
       (*new2old)[old2new[i]] = i;

--- a/textsearch/csrc/utils.cc
+++ b/textsearch/csrc/utils.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2023  Xiaomi Corporation
 #include "textsearch/csrc/utils.h"
 #include <assert.h>
+#include <vector>
 
 namespace fasttextsearch {
 
@@ -29,6 +30,30 @@ void RowIdsToRowSplits(int32_t num_elems, const uint32_t *row_ids,
   while (cur_row < num_rows) {
     row_splits[++cur_row] = num_elems;
   }
+}
+
+void GetNew2Old(const bool *keep, size_t num_old_elems,
+                std::vector<uint64_t> *new2old) {
+  auto old2new = std::vector<uint64_t>(num_old_elems);
+
+  // Exclusive sum
+  uint64_t sum = 0;
+  for (size_t i = 0; i != old2new.size(); ++i) {
+    old2new[i] = sum;
+    sum += (int)keep[i];
+  }
+  uint64_t num_new_elems = sum;
+
+  assert(num_new_elems >= 0);
+  assert(num_new_elems <= num_old_elems);
+
+  *new2old = std::vector<uint64_t>(num_new_elems + 1);
+  for (size_t i = 0; i != old2new.size(); ++i) {
+    if (i == old2new.size() - 1 || old2new[i + 1] > old2new[i])
+      (*new2old)[old2new[i]] = i;
+  }
+  *new2old = std::vector<uint64_t>(new2old->begin(),
+                                   new2old->begin() + new2old->size() - 1);
 }
 
 } // namespace fasttextsearch

--- a/textsearch/csrc/utils.h
+++ b/textsearch/csrc/utils.h
@@ -27,6 +27,14 @@ void RowIdsToRowSplits(int32_t num_elems, const uint32_t *row_ids,
 
 /** This function is copied/modified from
  * https://github.com/k2-fsa/k2/blob/master/k2/csrc/algorithms.h
+ *
+ * @param [in] keep  keep array of length num_old_elems indicating whether to
+ *                   keep current element.
+ * @param [in] num_old_elems  The number of elements of keep vector.
+ *
+ * @param [out] new2old  An array mapping the new indexes to the old indexes.
+ *                       Its dimension is the number of new indexes
+ *                       (i.e. the number of true in keep)
  */
 void GetNew2Old(const bool *keep, size_t num_old_elems,
                 std::vector<uint64_t> *new2old);

--- a/textsearch/csrc/utils.h
+++ b/textsearch/csrc/utils.h
@@ -5,6 +5,7 @@
 #ifndef TEXTSEARCH_CSRC_UTILS_H_
 #define TEXTSEARCH_CSRC_UTILS_H_
 #include <cstdint>
+#include <vector>
 
 namespace fasttextsearch {
 
@@ -24,6 +25,11 @@ namespace fasttextsearch {
 void RowIdsToRowSplits(int32_t num_elems, const uint32_t *row_ids,
                        int32_t num_rows, uint32_t *row_splits);
 
+/** This function is copied/modified from
+ * https://github.com/k2-fsa/k2/blob/master/k2/csrc/algorithms.h
+ */
+void GetNew2Old(const bool *keep, size_t num_old_elems,
+                std::vector<uint64_t> *new2old);
 } // namespace fasttextsearch
 
 #endif // TEXTSEARCH_CSRC_UTILS_H_

--- a/textsearch/csrc/utils.h
+++ b/textsearch/csrc/utils.h
@@ -4,6 +4,7 @@
 
 #ifndef TEXTSEARCH_CSRC_UTILS_H_
 #define TEXTSEARCH_CSRC_UTILS_H_
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 

--- a/textsearch/csrc/utils.h
+++ b/textsearch/csrc/utils.h
@@ -37,8 +37,8 @@ void RowIdsToRowSplits(int32_t num_elems, const uint32_t *row_ids,
  *                       Its dimension is the number of new indexes
  *                       (i.e. the number of true in keep)
  */
-void GetNew2Old(const bool *keep, size_t num_old_elems,
-                std::vector<uint64_t> *new2old);
+void GetNew2Old(const bool *keep, uint32_t num_old_elems,
+                std::vector<uint32_t> *new2old);
 } // namespace fasttextsearch
 
 #endif // TEXTSEARCH_CSRC_UTILS_H_

--- a/textsearch/python/csrc/utils.cc
+++ b/textsearch/python/csrc/utils.cc
@@ -38,6 +38,23 @@ static void PybindRowIdsToRowSplits(py::module &m) {
       py::arg("row_ids"), py::arg("row_splits"), kRowIdsToRowSplitsDoc);
 }
 
-void PybindUtils(py::module &m) { PybindRowIdsToRowSplits(m); }
+static void PybindGetNew2Old(py::module &m) {
+  m.def(
+      "get_new2old",
+      [](py::array_t<bool> keep) -> py::array_t<uint64_t> {
+        py::buffer_info keep_buf = keep.request();
+        size_t num_old_elems = keep_buf.size;
+        const bool *p_keep = static_cast<const bool *>(keep_buf.ptr);
+        std::vector<uint64_t> new2old;
+        GetNew2Old(p_keep, num_old_elems, &new2old);
+        return py::array(new2old.size(), new2old.data());
+      },
+      py::arg("keep"));
+}
+
+void PybindUtils(py::module &m) {
+  PybindGetNew2Old(m);
+  PybindRowIdsToRowSplits(m);
+}
 
 } // namespace fasttextsearch

--- a/textsearch/python/csrc/utils.cc
+++ b/textsearch/python/csrc/utils.cc
@@ -18,6 +18,23 @@ Args:
     On return it will contain the computed row splits.
 )doc";
 
+static constexpr const char *kGetNew2OldDoc = R"doc(
+Returns an array mapping the new indexes to the old indexes.
+Its dimension is the number of new indexes (i.e. the number of True in keep).
+
+Args:
+  keep:
+    A 1-D contiguous array of dtype np.bool indicating whether to keep current
+    element (True to keep, False to drop).
+
+>>> from textsearch import get_new2old
+>>> import numpy as np
+>>> keep = np.array([0, 0, 1, 0, 1, 0, 1, 1], dtype=bool)
+>>> get_new2old(keep)
+array([2, 4, 6, 7], dtype=uint64)
+
+)doc";
+
 static void PybindRowIdsToRowSplits(py::module &m) {
   m.def(
       "row_ids_to_row_splits",
@@ -49,7 +66,7 @@ static void PybindGetNew2Old(py::module &m) {
         GetNew2Old(p_keep, num_old_elems, &new2old);
         return py::array(new2old.size(), new2old.data());
       },
-      py::arg("keep"));
+      py::arg("keep"), kGetNew2OldDoc);
 }
 
 void PybindUtils(py::module &m) {

--- a/textsearch/python/csrc/utils.cc
+++ b/textsearch/python/csrc/utils.cc
@@ -31,7 +31,7 @@ Args:
 >>> import numpy as np
 >>> keep = np.array([0, 0, 1, 0, 1, 0, 1, 1], dtype=bool)
 >>> get_new2old(keep)
-array([2, 4, 6, 7], dtype=uint64)
+array([2, 4, 6, 7], dtype=uint32)
 
 )doc";
 
@@ -58,11 +58,11 @@ static void PybindRowIdsToRowSplits(py::module &m) {
 static void PybindGetNew2Old(py::module &m) {
   m.def(
       "get_new2old",
-      [](py::array_t<bool> keep) -> py::array_t<uint64_t> {
+      [](py::array_t<bool> keep) -> py::array_t<uint32_t> {
         py::buffer_info keep_buf = keep.request();
         size_t num_old_elems = keep_buf.size;
         const bool *p_keep = static_cast<const bool *>(keep_buf.ptr);
-        std::vector<uint64_t> new2old;
+        std::vector<uint32_t> new2old;
         GetNew2Old(p_keep, num_old_elems, &new2old);
         return py::array(new2old.size(), new2old.data());
       },

--- a/textsearch/python/tests/CMakeLists.txt
+++ b/textsearch/python/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ endfunction()
 
 if(FTS_ENABLE_TESTS)
   set(test_srcs
+    test_get_new2old.py
     test_levenshtein_distance.py
     test_row_ids_to_row_splits.py
     test_sourced_text.py

--- a/textsearch/python/tests/test_get_new2old.py
+++ b/textsearch/python/tests/test_get_new2old.py
@@ -11,23 +11,23 @@ class TestGetNew2Old(unittest.TestCase):
     def test_get_new2old_basic(self):
         keep = np.array([0, 1, 1, 0, 0, 1, 1, 0], dtype=bool)
         new2old = get_new2old(keep)
-        expected_new2old = np.array([1, 2, 5, 6], dtype=np.uint64)
+        expected_new2old = np.array([1, 2, 5, 6], dtype=np.uint32)
         np.testing.assert_equal(new2old, expected_new2old)
-        assert new2old.dtype == np.uint64, new2old.dtype
+        assert new2old.dtype == np.uint32, new2old.dtype
 
     def test_get_new2old_empty(self):
         keep = np.array([], dtype=bool)
         new2old = get_new2old(keep)
-        expected_new2old = np.array([], dtype=np.uint64)
+        expected_new2old = np.array([], dtype=np.uint32)
         np.testing.assert_equal(new2old, expected_new2old)
-        assert new2old.dtype == np.uint64, new2old.dtype
+        assert new2old.dtype == np.uint32, new2old.dtype
 
     def test_get_new2old_drop_all(self):
         keep = np.array([0, 0, 0, 0, 0, 0, 0], dtype=bool)
         new2old = get_new2old(keep)
-        expected_new2old = np.array([], dtype=np.uint64)
+        expected_new2old = np.array([], dtype=np.uint32)
         np.testing.assert_equal(new2old, expected_new2old)
-        assert new2old.dtype == np.uint64, new2old.dtype
+        assert new2old.dtype == np.uint32, new2old.dtype
 
 
 if __name__ == "__main__":

--- a/textsearch/python/tests/test_get_new2old.py
+++ b/textsearch/python/tests/test_get_new2old.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import numpy as np
+
+from textsearch import get_new2old
+
+
+class TestGetNew2Old(unittest.TestCase):
+    def test_get_new2old_basic(self):
+        keep = np.array([0, 1, 1, 0, 0, 1, 1, 0], dtype=bool)
+        new2old = get_new2old(keep)
+        expected_new2old = np.array([1, 2, 5, 6], dtype=np.uint64)
+        np.testing.assert_equal(new2old, expected_new2old)
+        assert new2old.dtype == np.uint64, new2old.dtype
+
+    def test_get_new2old_empty(self):
+        keep = np.array([], dtype=bool)
+        new2old = get_new2old(keep)
+        expected_new2old = np.array([], dtype=np.uint64)
+        np.testing.assert_equal(new2old, expected_new2old)
+        assert new2old.dtype == np.uint64, new2old.dtype
+
+    def test_get_new2old_drop_all(self):
+        keep = np.array([0, 0, 0, 0, 0, 0, 0], dtype=bool)
+        new2old = get_new2old(keep)
+        expected_new2old = np.array([], dtype=np.uint64)
+        np.testing.assert_equal(new2old, expected_new2old)
+        assert new2old.dtype == np.uint64, new2old.dtype
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/textsearch/python/tests/test_sourced_text.py
+++ b/textsearch/python/tests/test_sourced_text.py
@@ -8,6 +8,7 @@ from textsearch import SourcedText
 from textsearch import TextSource
 from textsearch import Transcript
 from textsearch import append_texts
+from textsearch import filter_texts
 from textsearch import texts_to_sourced_texts
 
 
@@ -213,6 +214,39 @@ class TestSourcedText(unittest.TestCase):
         )
         np.testing.assert_equal(sourced_text.doc_splits, expected_doc_splits)
         assert sourced_text.doc_splits.dtype == np.uint32, sourced_text.doc_splits.dtype
+
+    def test_filter_texts(self):
+        name0 = "test_filter_texts_0"
+        s0 = "Higher, faster, stronger, together"
+        text_source0 = TextSource.from_str(name=name0, s=s0, use_utf8=False)
+
+        sourced_text0 = texts_to_sourced_texts([text_source0])
+        sourced_text = append_texts([sourced_text0[0]])
+
+        # test keep
+        keep = np.array([True if x != "," else False for x in s0], dtype=bool)
+        new_sourced_text = filter_texts(sourced_text, keep=keep)
+
+        new_s0 = "Higher faster stronger together"
+        new_text_source0 = TextSource.from_str(name=name0, s=new_s0, use_utf8=False)
+        np.testing.assert_equal(
+            new_sourced_text.binary_text, new_text_source0.binary_text
+        )
+
+        new_pos_list = list(range(len(s0)))
+        new_pos_list.remove(6)
+        new_pos_list.remove(14)
+        new_pos_list.remove(24)
+        new_pos = np.array(new_pos_list, dtype=np.uint32)
+        np.testing.assert_equal(new_sourced_text.pos, new_pos)
+
+        # test fn
+        fn = lambda x: x != ord(",")
+        new_sourced_text = filter_texts(sourced_text, fn=fn)
+        np.testing.assert_equal(
+            new_sourced_text.binary_text, new_text_source0.binary_text
+        )
+        np.testing.assert_equal(new_sourced_text.pos, new_pos)
 
 
 if __name__ == "__main__":

--- a/textsearch/python/textsearch/__init__.py
+++ b/textsearch/python/textsearch/__init__.py
@@ -6,6 +6,7 @@ from .datatypes import TextSource
 from .datatypes import TextSources
 from .datatypes import Transcript
 from .datatypes import append_texts
+from .datatypes import filter_texts
 from .datatypes import texts_to_sourced_texts
 
 from .levenshtein import get_nice_alignments

--- a/textsearch/python/textsearch/__init__.py
+++ b/textsearch/python/textsearch/__init__.py
@@ -1,4 +1,5 @@
 from _fasttextsearch import levenshtein_distance
+from _fasttextsearch import get_new2old
 
 from .datatypes import SourcedText
 from .datatypes import TextSource


### PR DESCRIPTION
This is copied and modified from renumbering in k2, with a new2old mapping we can keep track of the origin indexes after removing some elements from the raw text.

```
>>> from textsearch import get_new2old
>>> import numpy as np
>>> keep = np.array([0, 0, 1, 0, 1, 0, 1, 1], dtype=bool)
>>> get_new2old(keep)
array([2, 4, 6, 7], dtype=uint64)
```