### PR TITLE
Hide the implementation detail of create_suffix_array.

### DIFF
--- a/.github/workflows/linux-macos.yaml
+++ b/.github/workflows/linux-macos.yaml
@@ -8,8 +8,8 @@ on:
       - '.github/workflows/linux-macos.yaml'
       - 'CMakeLists.txt'
       - 'cmake/**'
-      - 'textsearch/csrc/*'
-      - 'textsearch/python/*'
+      - 'textsearch/csrc/**'
+      - 'textsearch/python/**'
   pull_request:
     branches:
       - master
@@ -17,8 +17,8 @@ on:
       - '.github/workflows/linux-macos.yaml'
       - 'CMakeLists.txt'
       - 'cmake/**'
-      - 'textsearch/csrc/*'
-      - 'textsearch/python/*'
+      - 'textsearch/csrc/**'
+      - 'textsearch/python/**'
 
 concurrency:
   group: linux-macos-${{ github.ref }}

--- a/textsearch/python/tests/test_suffix_array.py
+++ b/textsearch/python/tests/test_suffix_array.py
@@ -29,7 +29,7 @@ from textsearch import create_suffix_array, find_close_matches
 class TestSuffixArray(unittest.TestCase):
     def test_create_suffix_array(self):
         for dtype in [np.uint8, np.int8, np.uint16, np.int16]:
-            array = np.array([3, 2, 1, np.iinfo(dtype).max - 1, 0, 0, 0], dtype=dtype)
+            array = np.array([3, 2, 1], dtype=dtype)
             suffix_array = create_suffix_array(array)
             expected_array = np.array([2, 1, 0, 3], dtype=np.int64)
             self.assertTrue((suffix_array == expected_array).all())
@@ -78,12 +78,7 @@ class TestSuffixArray(unittest.TestCase):
 
         # texts will be : "hellohalloiholloyouyouhellome"
         texts = "".join(queries) + "".join(documents)
-        texts_array = [ord(x) for x in texts] + [
-            np.iinfo(np.int8).max - 1,  # for ascii
-            0,
-            0,
-            0,
-        ]
+        texts_array = [ord(x) for x in texts]
         texts_array = np.array(texts_array, dtype=np.int8)
         suffix_array = create_suffix_array(texts_array)
 

--- a/textsearch/python/textsearch/suffix_array.py
+++ b/textsearch/python/textsearch/suffix_array.py
@@ -18,36 +18,38 @@ import _fasttextsearch
 import numpy as np
 
 
-def create_suffix_array(input: np.ndarray) -> np.ndarray:
-    """
-    Creates a suffix array from the input text and returns it as a NumPy array.  Read
-    the usage carefully as it has some special requirements that will require careful data
-    preparation.
+def create_suffix_array(array: np.ndarray) -> np.ndarray:
+    """Create a suffix array from a 1-D input array.
+
+    hint:
+      Please refer to https://en.wikipedia.org/wiki/Suffix_array
+      for what suffix array is. Different from the above Wikipedia
+      article the special sentinel letter ``$`` in fasttextsearch
+      is known as EOS and it is larger than any other characters.
 
     Args:
-       input: an integer (or unsigned integer) type of np.ndarray.  Its shape
-          should be (seq_len + 3,) where `seq_len` is the text sequence length INCLUDING
-          EOS SYMBOL.
-          The EOS (end of sequence) symbol must be the second largest element of the
-          type (i.e. of the form 2^n - 2), must be located at input[seq_len - 1] and
-          must appear nowhere else in `input` (you may have to map the input
-          symbols somehow to achieve this).  It must be followed by 3 zeros, for reasons
-          related to how the algorithm works.
+      array:
+        A 1-D integer (or unsigned integer) array of shape (seq_len,).
+        Note: Inside this function, we will append explicitly an EOS
+        symbol that is larger than ``array.max()``.
     Returns:
-          Returns a suffix array of type np.int64,
-          of shape (seq_len,).  This will consist of some permutation of the elements
-          0 .. seq_len - 1.
+      Returns a suffix array of type np.int64, of shape (seq_len,).
+      This will consist of some permutation of the elements
+      ``0 .. seq_len - 1``.
     """
-    assert input.ndim == 1, input.ndim
-    seq_len = input.size - 3
-    assert seq_len >= 1, seq_len
-    max_symbol = input[seq_len - 1]
-    assert max_symbol == np.iinfo(input.dtype).max - 1, max_symbol
-    assert bool(input[seq_len:].any()) is False, input[seq_len:]
+    assert array.ndim == 1, array.ndim
+
+    # TODO(fangjun): Support renumbering
+    max_symbol = array.max()
+    assert max_symbol < np.iinfo(array.dtype).max - 1, max_symbol
+    eos = max_symbol + 1
+    padding = np.array([eos, 0, 0, 0], dtype=array.dtype)
+
+    padded_array = np.concatenate([array, padding])
 
     # The C++ code requires the input array to be contiguous.
-    input64 = np.ascontiguousarray(input, dtype=np.int64)
-    return _fasttextsearch.create_suffix_array(input64)
+    array_int64 = np.ascontiguousarray(padded_array, dtype=np.int64)
+    return _fasttextsearch.create_suffix_array(array_int64)
 
 
 def find_close_matches(suffix_array: np.ndarray, query_len: int) -> np.ndarray:


### PR DESCRIPTION
We manually pad the input array to simplify the calling interface.

Also, we can add renumbering later inside.